### PR TITLE
Implement event scheduler with wheel and micro queue

### DIFF
--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/EvType.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/EvType.java
@@ -1,0 +1,13 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+/** Enumeration of supported scheduler event types. */
+public enum EvType {
+  BLOCK_SCHEDULED_TICK,
+  NEIGHBOR_CHANGE,
+  POWER_PROPAGATION,
+  COMPONENT_EVAL,
+  PISTON_TXN,
+  OBSERVER_PULSE,
+  NETLIST_INVALIDATE,
+  ADMIN_CONTROL
+}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/Event.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/Event.java
@@ -1,0 +1,55 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import dev.fastquartz.fastquartz.engine.BlockPos;
+import java.util.Objects;
+
+/** Compact event payload describing simulation work. */
+public final class Event {
+  private final EventKey key;
+  private final EvType type;
+  private final BlockPos pos;
+  private final int aux;
+  private final @Nullable Object data;
+
+  public Event(EventKey key, EvType type, BlockPos pos, int aux, @Nullable Object data) {
+    this.key = Objects.requireNonNull(key, "key");
+    this.type = Objects.requireNonNull(type, "type");
+    this.pos = Objects.requireNonNull(pos, "pos");
+    this.aux = aux;
+    this.data = data;
+  }
+
+  public EventKey key() {
+    return this.key;
+  }
+
+  public EvType type() {
+    return this.type;
+  }
+
+  public BlockPos pos() {
+    return this.pos;
+  }
+
+  public int aux() {
+    return this.aux;
+  }
+
+  public @Nullable Object data() {
+    return this.data;
+  }
+
+  @Override
+  public String toString() {
+    return "Event{"
+        + "key="
+        + this.key
+        + ", type="
+        + this.type
+        + ", pos="
+        + this.pos
+        + ", aux="
+        + this.aux
+        + '}';
+  }
+}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/EventKey.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/EventKey.java
@@ -6,7 +6,10 @@ import dev.fastquartz.fastquartz.engine.BlockPos;
 public record EventKey(long tick, int micro, int regionId, long localOrder)
     implements Comparable<EventKey> {
 
-  private static final long COORD_MASK = (1L << 20) - 1L;
+  private static final int AXIS_BITS = 20;
+  private static final int TYPE_BITS = 4;
+  private static final long AXIS_MASK = (1L << AXIS_BITS) - 1L;
+  private static final long AXIS_OFFSET = 1L << (AXIS_BITS - 1);
 
   @Override
   public int compareTo(EventKey other) {
@@ -25,22 +28,31 @@ public record EventKey(long tick, int micro, int regionId, long localOrder)
     if (regionCompare != 0) {
       return regionCompare;
     }
-    return Long.compare(this.localOrder, other.localOrder);
+    return Long.compareUnsigned(this.localOrder, other.localOrder);
   }
 
   /**
    * Computes a deterministic intra-tick ordering value using Y-major packing of the block position
-   * along with the event type ordinal.
+   * along with the event type ordinal. Coordinates are normalised into a 20-bit signed range so that
+   * the resulting {@code long} can be compared using unsigned semantics while preserving the
+   * lexicographic (Y, Z, X, type) ordering requirements.
    */
   @SuppressWarnings("EnumOrdinal")
   public static long localOrder(BlockPos pos, EvType type) {
     long yBits = compactCoordinate(pos.y());
     long zBits = compactCoordinate(pos.z());
     long xBits = compactCoordinate(pos.x());
-    return (yBits << 40) | (zBits << 20) | (xBits << 4) | (long) type.ordinal();
+    return (yBits << (AXIS_BITS * 2 + TYPE_BITS))
+        | (zBits << (AXIS_BITS + TYPE_BITS))
+        | (xBits << TYPE_BITS)
+        | (long) type.ordinal();
   }
 
   private static long compactCoordinate(int value) {
-    return ((long) value) & COORD_MASK;
+    long adjusted = (long) value + AXIS_OFFSET;
+    if (adjusted < 0L || adjusted > AXIS_MASK) {
+      throw new IllegalArgumentException("Coordinate out of supported range: " + value);
+    }
+    return adjusted;
   }
 }

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/EventKey.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/EventKey.java
@@ -1,0 +1,46 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import dev.fastquartz.fastquartz.engine.BlockPos;
+
+/** Stable ordering key for scheduled events. */
+public record EventKey(long tick, int micro, int regionId, long localOrder)
+    implements Comparable<EventKey> {
+
+  private static final long COORD_MASK = (1L << 20) - 1L;
+
+  @Override
+  public int compareTo(EventKey other) {
+    if (this == other) {
+      return 0;
+    }
+    int tickCompare = Long.compare(this.tick, other.tick);
+    if (tickCompare != 0) {
+      return tickCompare;
+    }
+    int microCompare = Integer.compare(this.micro, other.micro);
+    if (microCompare != 0) {
+      return microCompare;
+    }
+    int regionCompare = Integer.compare(this.regionId, other.regionId);
+    if (regionCompare != 0) {
+      return regionCompare;
+    }
+    return Long.compare(this.localOrder, other.localOrder);
+  }
+
+  /**
+   * Computes a deterministic intra-tick ordering value using Y-major packing of the block position
+   * along with the event type ordinal.
+   */
+  @SuppressWarnings("EnumOrdinal")
+  public static long localOrder(BlockPos pos, EvType type) {
+    long yBits = compactCoordinate(pos.y());
+    long zBits = compactCoordinate(pos.z());
+    long xBits = compactCoordinate(pos.x());
+    return (yBits << 40) | (zBits << 20) | (xBits << 4) | (long) type.ordinal();
+  }
+
+  private static long compactCoordinate(int value) {
+    return ((long) value) & COORD_MASK;
+  }
+}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/MicroPriorityQueue.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/MicroPriorityQueue.java
@@ -1,0 +1,132 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import dev.fastquartz.fastquartz.engine.BlockPos;
+import java.util.Arrays;
+
+/** Binary heap implementation specialised for {@link Event} ordering. */
+final class MicroPriorityQueue {
+  private static final int DEFAULT_CAPACITY = 64;
+
+  private Event[] heap;
+  private int size;
+
+  MicroPriorityQueue() {
+    this(DEFAULT_CAPACITY);
+  }
+
+  MicroPriorityQueue(int initialCapacity) {
+    if (initialCapacity <= 0) {
+      throw new IllegalArgumentException("initialCapacity must be positive");
+    }
+    this.heap = new Event[initialCapacity];
+    this.size = 0;
+  }
+
+  void offer(Event event) {
+    ensureCapacity();
+    this.heap[this.size] = event;
+    siftUp(this.size);
+    this.size++;
+  }
+
+  @Nullable
+  Event poll() {
+    if (this.size == 0) {
+      return null;
+    }
+    Event result = this.heap[0];
+    int newSize = --this.size;
+    Event last = this.heap[newSize];
+    this.heap[newSize] = null;
+    if (newSize > 0) {
+      this.heap[0] = last;
+      siftDown(0);
+    }
+    return result;
+  }
+
+  boolean isEmpty() {
+    return this.size == 0;
+  }
+
+  int size() {
+    return this.size;
+  }
+
+  int remove(BlockPos pos, EvType type) {
+    int removed = 0;
+    int index = 0;
+    while (index < this.size) {
+      Event event = this.heap[index];
+      if (event != null && event.pos().equals(pos) && event.type() == type) {
+        removed++;
+        removeAt(index);
+      } else {
+        index++;
+      }
+    }
+    return removed;
+  }
+
+  private void removeAt(int index) {
+    int newSize = --this.size;
+    Event last = this.heap[newSize];
+    this.heap[newSize] = null;
+    if (index == newSize) {
+      return;
+    }
+    this.heap[index] = last;
+    siftDown(index);
+    siftUp(index);
+  }
+
+  private void ensureCapacity() {
+    if (this.size < this.heap.length) {
+      return;
+    }
+    int newCapacity = this.heap.length + (this.heap.length >> 1);
+    if (newCapacity == this.heap.length) {
+      newCapacity++;
+    }
+    this.heap = Arrays.copyOf(this.heap, newCapacity);
+  }
+
+  private void siftUp(int index) {
+    Event event = this.heap[index];
+    while (index > 0) {
+      int parent = (index - 1) >>> 1;
+      Event parentEvent = this.heap[parent];
+      if (compare(event, parentEvent) >= 0) {
+        break;
+      }
+      this.heap[index] = parentEvent;
+      index = parent;
+    }
+    this.heap[index] = event;
+  }
+
+  private void siftDown(int index) {
+    Event event = this.heap[index];
+    int half = this.size >>> 1;
+    while (index < half) {
+      int left = (index << 1) + 1;
+      int right = left + 1;
+      int smallest = left;
+      Event leftEvent = this.heap[left];
+      if (right < this.size && compare(this.heap[right], leftEvent) < 0) {
+        smallest = right;
+      }
+      Event smallestEvent = this.heap[smallest];
+      if (compare(event, smallestEvent) <= 0) {
+        break;
+      }
+      this.heap[index] = smallestEvent;
+      index = smallest;
+    }
+    this.heap[index] = event;
+  }
+
+  private static int compare(Event first, Event second) {
+    return first.key().compareTo(second.key());
+  }
+}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/Nullable.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/Nullable.java
@@ -1,0 +1,13 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Lightweight {@code Nullable} marker to avoid external annotation dependencies. */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+public @interface Nullable {}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/Scheduler.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/Scheduler.java
@@ -1,0 +1,24 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import dev.fastquartz.fastquartz.engine.BlockPos;
+import java.util.List;
+
+/** API for the two-level event scheduler. */
+public interface Scheduler {
+  void scheduleAtTick(Event event, long tickDue);
+
+  void scheduleMicro(Event event, int microDue);
+
+  void cancelAt(BlockPos pos, EvType type);
+
+  boolean hasDueAt(long tick);
+
+  List<Event> drainTick(long tick);
+
+  @Nullable
+  Event pollMicro();
+
+  void offerMicro(Event event);
+
+  SchedulerMetrics metrics();
+}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/SchedulerMetrics.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/SchedulerMetrics.java
@@ -1,0 +1,131 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/** Aggregated scheduler metrics for operations and latency accounting. */
+public final class SchedulerMetrics {
+  private final LongAdder scheduleAtTickOps = new LongAdder();
+  private final LongAdder scheduleAtTickLatencyNanos = new LongAdder();
+  private final LongAdder scheduleMicroOps = new LongAdder();
+  private final LongAdder scheduleMicroLatencyNanos = new LongAdder();
+  private final LongAdder offerMicroOps = new LongAdder();
+  private final LongAdder offerMicroLatencyNanos = new LongAdder();
+  private final LongAdder pollMicroOps = new LongAdder();
+  private final LongAdder pollMicroLatencyNanos = new LongAdder();
+  private final LongAdder drainTickOps = new LongAdder();
+  private final LongAdder drainTickLatencyNanos = new LongAdder();
+  private final LongAdder cancelOps = new LongAdder();
+  private final LongAdder cancelLatencyNanos = new LongAdder();
+
+  long startTimer() {
+    return System.nanoTime();
+  }
+
+  void recordScheduleAtTick(long startNanos) {
+    record(scheduleAtTickOps, scheduleAtTickLatencyNanos, startNanos);
+  }
+
+  void recordScheduleMicro(long startNanos) {
+    record(scheduleMicroOps, scheduleMicroLatencyNanos, startNanos);
+  }
+
+  void recordOfferMicro(long startNanos) {
+    record(offerMicroOps, offerMicroLatencyNanos, startNanos);
+  }
+
+  void recordPollMicro(long startNanos) {
+    record(pollMicroOps, pollMicroLatencyNanos, startNanos);
+  }
+
+  void recordDrainTick(long startNanos) {
+    record(drainTickOps, drainTickLatencyNanos, startNanos);
+  }
+
+  void recordCancel(long startNanos) {
+    record(cancelOps, cancelLatencyNanos, startNanos);
+  }
+
+  private static void record(LongAdder ops, LongAdder nanos, long startNanos) {
+    ops.increment();
+    nanos.add(System.nanoTime() - startNanos);
+  }
+
+  public long scheduleAtTickOps() {
+    return scheduleAtTickOps.sum();
+  }
+
+  public long scheduleAtTickLatencyNanos() {
+    return scheduleAtTickLatencyNanos.sum();
+  }
+
+  public double scheduleAtTickAverageMicros() {
+    return averageMicros(scheduleAtTickLatencyNanos.sum(), scheduleAtTickOps.sum());
+  }
+
+  public long scheduleMicroOps() {
+    return scheduleMicroOps.sum();
+  }
+
+  public long scheduleMicroLatencyNanos() {
+    return scheduleMicroLatencyNanos.sum();
+  }
+
+  public double scheduleMicroAverageMicros() {
+    return averageMicros(scheduleMicroLatencyNanos.sum(), scheduleMicroOps.sum());
+  }
+
+  public long offerMicroOps() {
+    return offerMicroOps.sum();
+  }
+
+  public long offerMicroLatencyNanos() {
+    return offerMicroLatencyNanos.sum();
+  }
+
+  public double offerMicroAverageMicros() {
+    return averageMicros(offerMicroLatencyNanos.sum(), offerMicroOps.sum());
+  }
+
+  public long pollMicroOps() {
+    return pollMicroOps.sum();
+  }
+
+  public long pollMicroLatencyNanos() {
+    return pollMicroLatencyNanos.sum();
+  }
+
+  public double pollMicroAverageMicros() {
+    return averageMicros(pollMicroLatencyNanos.sum(), pollMicroOps.sum());
+  }
+
+  public long drainTickOps() {
+    return drainTickOps.sum();
+  }
+
+  public long drainTickLatencyNanos() {
+    return drainTickLatencyNanos.sum();
+  }
+
+  public double drainTickAverageMicros() {
+    return averageMicros(drainTickLatencyNanos.sum(), drainTickOps.sum());
+  }
+
+  public long cancelOps() {
+    return cancelOps.sum();
+  }
+
+  public long cancelLatencyNanos() {
+    return cancelLatencyNanos.sum();
+  }
+
+  public double cancelAverageMicros() {
+    return averageMicros(cancelLatencyNanos.sum(), cancelOps.sum());
+  }
+
+  private static double averageMicros(long nanos, long ops) {
+    if (ops == 0L) {
+      return 0.0d;
+    }
+    return nanos / (double) ops / 1_000.0d;
+  }
+}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/TickWheelScheduler.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/scheduler/TickWheelScheduler.java
@@ -1,0 +1,157 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import dev.fastquartz.fastquartz.engine.BlockPos;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Two-level scheduler backed by a hashed timing wheel and a deterministic micro-priority queue. */
+public final class TickWheelScheduler implements Scheduler {
+  private static final int DEFAULT_WHEEL_SIZE = 4096;
+
+  private final ArrayDeque<Event>[] wheel;
+  private final MicroPriorityQueue microQueue;
+  private final int mask;
+  private final SchedulerMetrics metrics = new SchedulerMetrics();
+
+  public TickWheelScheduler() {
+    this(DEFAULT_WHEEL_SIZE);
+  }
+
+  @SuppressWarnings("unchecked")
+  public TickWheelScheduler(int wheelSize) {
+    if (wheelSize <= 0 || (wheelSize & (wheelSize - 1)) != 0) {
+      throw new IllegalArgumentException("wheelSize must be a positive power-of-two");
+    }
+    this.wheel = (ArrayDeque<Event>[]) new ArrayDeque<?>[wheelSize];
+    for (int i = 0; i < wheelSize; i++) {
+      this.wheel[i] = new ArrayDeque<>();
+    }
+    this.microQueue = new MicroPriorityQueue();
+    this.mask = wheelSize - 1;
+  }
+
+  @Override
+  public void scheduleAtTick(Event event, long tickDue) {
+    Objects.requireNonNull(event, "event");
+    if (event.key().tick() != tickDue) {
+      throw new IllegalArgumentException("event key tick mismatch");
+    }
+    long start = this.metrics.startTimer();
+    try {
+      this.wheel[indexFor(tickDue)].addLast(event);
+    } finally {
+      this.metrics.recordScheduleAtTick(start);
+    }
+  }
+
+  @Override
+  public void scheduleMicro(Event event, int microDue) {
+    Objects.requireNonNull(event, "event");
+    if (event.key().micro() != microDue) {
+      throw new IllegalArgumentException("event key micro mismatch");
+    }
+    long start = this.metrics.startTimer();
+    try {
+      this.microQueue.offer(event);
+    } finally {
+      this.metrics.recordScheduleMicro(start);
+    }
+  }
+
+  @Override
+  public void cancelAt(BlockPos pos, EvType type) {
+    Objects.requireNonNull(pos, "pos");
+    Objects.requireNonNull(type, "type");
+    long start = this.metrics.startTimer();
+    try {
+      this.microQueue.remove(pos, type);
+      for (ArrayDeque<Event> slot : this.wheel) {
+        if (slot.isEmpty()) {
+          continue;
+        }
+        int iterations = slot.size();
+        for (int i = 0; i < iterations; i++) {
+          Event event = slot.removeFirst();
+          if (event.pos().equals(pos) && event.type() == type) {
+            continue;
+          }
+          slot.addLast(event);
+        }
+      }
+    } finally {
+      this.metrics.recordCancel(start);
+    }
+  }
+
+  @Override
+  public boolean hasDueAt(long tick) {
+    ArrayDeque<Event> slot = this.wheel[indexFor(tick)];
+    if (slot.isEmpty()) {
+      return false;
+    }
+    for (Event event : slot) {
+      if (event.key().tick() <= tick) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public List<Event> drainTick(long tick) {
+    long start = this.metrics.startTimer();
+    try {
+      ArrayDeque<Event> slot = this.wheel[indexFor(tick)];
+      List<Event> drained = new ArrayList<>(slot.size());
+      if (slot.isEmpty()) {
+        return drained;
+      }
+      int iterations = slot.size();
+      for (int i = 0; i < iterations; i++) {
+        Event event = slot.removeFirst();
+        if (event.key().tick() <= tick) {
+          this.microQueue.offer(event);
+          drained.add(event);
+        } else {
+          slot.addLast(event);
+        }
+      }
+      return drained;
+    } finally {
+      this.metrics.recordDrainTick(start);
+    }
+  }
+
+  @Override
+  public @Nullable Event pollMicro() {
+    long start = this.metrics.startTimer();
+    try {
+      return this.microQueue.poll();
+    } finally {
+      this.metrics.recordPollMicro(start);
+    }
+  }
+
+  @Override
+  public void offerMicro(Event event) {
+    Objects.requireNonNull(event, "event");
+    long start = this.metrics.startTimer();
+    try {
+      this.microQueue.offer(event);
+    } finally {
+      this.metrics.recordOfferMicro(start);
+    }
+  }
+
+  @Override
+  public SchedulerMetrics metrics() {
+    return this.metrics;
+  }
+
+  private int indexFor(long tick) {
+    return (int) (tick & this.mask);
+  }
+}

--- a/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/EventKeyOrderingTest.java
+++ b/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/EventKeyOrderingTest.java
@@ -1,0 +1,47 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.Test;
+
+class EventKeyOrderingTest {
+  private static final int SAMPLE_SIZE = 100_000;
+
+  @Test
+  void compareToIsAntisymmetric() {
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    for (int i = 0; i < SAMPLE_SIZE; i++) {
+      EventKey first = randomKey(random);
+      EventKey second = randomKey(random);
+      int forward = Integer.signum(first.compareTo(second));
+      int backward = Integer.signum(second.compareTo(first));
+      assertEquals(-forward, backward, "Ordering must be antisymmetric");
+    }
+  }
+
+  @Test
+  void compareToIsTransitive() {
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    for (int i = 0; i < SAMPLE_SIZE; i++) {
+      EventKey a = randomKey(random);
+      EventKey b = randomKey(random);
+      EventKey c = randomKey(random);
+      if (a.compareTo(b) <= 0 && b.compareTo(c) <= 0) {
+        assertTrue(a.compareTo(c) <= 0, "Ordering must be transitive (ascending)");
+      }
+      if (a.compareTo(b) >= 0 && b.compareTo(c) >= 0) {
+        assertTrue(a.compareTo(c) >= 0, "Ordering must be transitive (descending)");
+      }
+    }
+  }
+
+  private static EventKey randomKey(ThreadLocalRandom random) {
+    long tick = random.nextLong(0L, 1_000_000L);
+    int micro = random.nextInt(0, 1_024);
+    int region = random.nextInt(0, 64);
+    long local = random.nextLong();
+    return new EventKey(tick, micro, region, local);
+  }
+}

--- a/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/EventKeyOrderingTest.java
+++ b/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/EventKeyOrderingTest.java
@@ -3,6 +3,7 @@ package dev.fastquartz.fastquartz.engine.scheduler;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import dev.fastquartz.fastquartz.engine.BlockPos;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.jupiter.api.Test;
 
@@ -37,11 +38,47 @@ class EventKeyOrderingTest {
     }
   }
 
+  @Test
+  void localOrderRespectsBlockPosOrdering() {
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    for (int i = 0; i < SAMPLE_SIZE; i++) {
+      BlockPos first = randomPos(random);
+      BlockPos second = randomPos(random);
+      long firstOrder = EventKey.localOrder(first, EvType.BLOCK_SCHEDULED_TICK);
+      long secondOrder = EventKey.localOrder(second, EvType.BLOCK_SCHEDULED_TICK);
+      int expected = Integer.signum(first.compareTo(second));
+      int actual = Integer.signum(Long.compareUnsigned(firstOrder, secondOrder));
+      assertEquals(expected, Integer.signum(actual), "localOrder must follow BlockPos ordering");
+    }
+  }
+
+  @Test
+  void localOrderBreaksTiesUsingEventType() {
+    BlockPos pos = new BlockPos(4, 2, -3);
+    EvType[] types = EvType.values();
+    long previous = EventKey.localOrder(pos, types[0]);
+    for (int i = 1; i < types.length; i++) {
+      long encoded = EventKey.localOrder(pos, types[i]);
+      assertTrue(
+          Long.compareUnsigned(previous, encoded) < 0,
+          "Type ordinal should strictly increase local order");
+      previous = encoded;
+    }
+  }
+
   private static EventKey randomKey(ThreadLocalRandom random) {
     long tick = random.nextLong(0L, 1_000_000L);
     int micro = random.nextInt(0, 1_024);
     int region = random.nextInt(0, 64);
     long local = random.nextLong();
     return new EventKey(tick, micro, region, local);
+  }
+
+  private static BlockPos randomPos(ThreadLocalRandom random) {
+    int limit = 1 << 19;
+    int x = random.nextInt(-limit, limit);
+    int y = random.nextInt(-limit, limit);
+    int z = random.nextInt(-limit, limit);
+    return new BlockPos(x, y, z);
   }
 }

--- a/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/SchedulerDeterminismTest.java
+++ b/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/SchedulerDeterminismTest.java
@@ -1,0 +1,57 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.fastquartz.fastquartz.engine.BlockPos;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+class SchedulerDeterminismTest {
+  private static final int EVENT_COUNT = 512;
+
+  @Test
+  void dequeueOrderIsStableAcrossRuns() {
+    List<Event> events = randomEvents(0x5EEDL);
+    List<EventKey> firstRun = drainInOrder(events);
+    List<EventKey> secondRun = drainInOrder(events);
+    assertEquals(firstRun, secondRun, "Scheduling order must be deterministic");
+  }
+
+  private static List<Event> randomEvents(long seed) {
+    Random random = new Random(seed);
+    EvType[] types = EvType.values();
+    List<Event> events = new ArrayList<>(EVENT_COUNT);
+    for (int i = 0; i < EVENT_COUNT; i++) {
+      long tick = random.nextInt(2_048);
+      int micro = random.nextInt(64);
+      int region = random.nextInt(16);
+      BlockPos pos = new BlockPos(random.nextInt(64) - 32, random.nextInt(32), random.nextInt(64) - 32);
+      EvType type = types[random.nextInt(types.length)];
+      events.add(TestEventFactory.create(tick, micro, region, pos, type));
+    }
+    return events;
+  }
+
+  private static List<EventKey> drainInOrder(List<Event> events) {
+    TickWheelScheduler scheduler = new TickWheelScheduler(64);
+    long maxTick = 0L;
+    for (Event event : events) {
+      scheduler.scheduleAtTick(event, event.key().tick());
+      maxTick = Math.max(maxTick, event.key().tick());
+    }
+    List<EventKey> observed = new ArrayList<>(events.size());
+    for (long tick = 0; tick <= maxTick; tick++) {
+      scheduler.drainTick(tick);
+      Event next;
+      while ((next = scheduler.pollMicro()) != null) {
+        assertTrue(next.key().tick() <= tick, "Events must not fire before their tick");
+        observed.add(next.key());
+      }
+    }
+    assertEquals(events.size(), observed.size());
+    return observed;
+  }
+}

--- a/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/SchedulerLatencyTest.java
+++ b/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/SchedulerLatencyTest.java
@@ -1,0 +1,69 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.fastquartz.fastquartz.engine.BlockPos;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SchedulerLatencyTest {
+  private static final int EVENT_COUNT = 10_000;
+  private static final double BUDGET_MICROS = 200.0d;
+
+  @Test
+  void enqueueAndDequeueStayWithinLatencyBudget() {
+    TickWheelScheduler scheduler = new TickWheelScheduler();
+    List<Event> events = new ArrayList<>(EVENT_COUNT);
+    EvType[] types = EvType.values();
+    for (int i = 0; i < EVENT_COUNT; i++) {
+      long tick = i;
+      int micro = i & 0x0F;
+      int region = i & 0x07;
+      BlockPos pos = new BlockPos(i & 0x3F, (i >> 3) & 0x3F, (i >> 6) & 0x3F);
+      EvType type = types[i % types.length];
+      events.add(TestEventFactory.create(tick, micro, region, pos, type));
+    }
+
+    long scheduleStart = System.nanoTime();
+    for (Event event : events) {
+      scheduler.scheduleAtTick(event, event.key().tick());
+    }
+    long scheduleDuration = System.nanoTime() - scheduleStart;
+
+    long drainStart = System.nanoTime();
+    for (long tick = 0; tick < EVENT_COUNT; tick++) {
+      scheduler.drainTick(tick);
+    }
+    long drainDuration = System.nanoTime() - drainStart;
+
+    long pollStart = System.nanoTime();
+    for (int i = 0; i < EVENT_COUNT; i++) {
+      assertTrue(scheduler.pollMicro() != null);
+    }
+    long pollDuration = System.nanoTime() - pollStart;
+
+    assertTrue(scheduler.pollMicro() == null, "Queue should be empty after draining all events");
+
+    double scheduleAverage = nanosToMicros(scheduleDuration) / EVENT_COUNT;
+    double drainAverage = nanosToMicros(drainDuration) / EVENT_COUNT;
+    double pollAverage = nanosToMicros(pollDuration) / EVENT_COUNT;
+
+    assertTrue(scheduleAverage < BUDGET_MICROS, "scheduleAtTick should stay within budget");
+    assertTrue(drainAverage < BUDGET_MICROS, "drainTick should stay within budget");
+    assertTrue(pollAverage < BUDGET_MICROS, "pollMicro should stay within budget");
+
+    SchedulerMetrics metrics = scheduler.metrics();
+    assertEquals(EVENT_COUNT, metrics.scheduleAtTickOps());
+    assertEquals(EVENT_COUNT, metrics.drainTickOps());
+    assertEquals(EVENT_COUNT + 1L, metrics.pollMicroOps());
+    assertTrue(metrics.scheduleAtTickAverageMicros() < BUDGET_MICROS);
+    assertTrue(metrics.drainTickAverageMicros() < BUDGET_MICROS);
+    assertTrue(metrics.pollMicroAverageMicros() < BUDGET_MICROS);
+  }
+
+  private static double nanosToMicros(long nanos) {
+    return nanos / 1_000.0d;
+  }
+}

--- a/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/SchedulerMicroOrderingTest.java
+++ b/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/SchedulerMicroOrderingTest.java
@@ -1,0 +1,27 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.fastquartz.fastquartz.engine.BlockPos;
+import org.junit.jupiter.api.Test;
+
+class SchedulerMicroOrderingTest {
+  @Test
+  void scheduleMicroRespectsOrdering() {
+    TickWheelScheduler scheduler = new TickWheelScheduler();
+    Event first =
+        TestEventFactory.create(42, 1, 0, new BlockPos(0, 0, 0), EvType.COMPONENT_EVAL);
+    Event second =
+        TestEventFactory.create(42, 5, 0, new BlockPos(1, 0, 0), EvType.COMPONENT_EVAL);
+    Event third =
+        TestEventFactory.create(42, 9, 0, new BlockPos(2, 0, 0), EvType.COMPONENT_EVAL);
+
+    scheduler.scheduleMicro(second, second.key().micro());
+    scheduler.scheduleMicro(third, third.key().micro());
+    scheduler.scheduleMicro(first, first.key().micro());
+
+    assertEquals(first.key(), scheduler.pollMicro().key());
+    assertEquals(second.key(), scheduler.pollMicro().key());
+    assertEquals(third.key(), scheduler.pollMicro().key());
+  }
+}

--- a/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/TestEventFactory.java
+++ b/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/TestEventFactory.java
@@ -1,0 +1,17 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import dev.fastquartz.fastquartz.engine.BlockPos;
+
+final class TestEventFactory {
+  private TestEventFactory() {}
+
+  static Event create(long tick, int micro, int regionId, BlockPos pos, EvType type) {
+    return create(tick, micro, regionId, pos, type, 0, null);
+  }
+
+  static Event create(
+      long tick, int micro, int regionId, BlockPos pos, EvType type, int aux, Object data) {
+    EventKey key = new EventKey(tick, micro, regionId, EventKey.localOrder(pos, type));
+    return new Event(key, type, pos, aux, data);
+  }
+}

--- a/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/TickWheelSchedulerWheelWrapTest.java
+++ b/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/scheduler/TickWheelSchedulerWheelWrapTest.java
@@ -1,0 +1,48 @@
+package dev.fastquartz.fastquartz.engine.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.fastquartz.fastquartz.engine.BlockPos;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TickWheelSchedulerWheelWrapTest {
+  @Test
+  void eventsBeyondWheelSizeFireOnCorrectTick() {
+    int wheelSize = 8;
+    TickWheelScheduler scheduler = new TickWheelScheduler(wheelSize);
+    List<Event> events = List.of(
+        TestEventFactory.create(1, 0, 0, new BlockPos(1, 0, 0), EvType.BLOCK_SCHEDULED_TICK),
+        TestEventFactory.create(9, 0, 0, new BlockPos(2, 0, 0), EvType.NEIGHBOR_CHANGE),
+        TestEventFactory.create(17, 0, 0, new BlockPos(3, 0, 0), EvType.POWER_PROPAGATION));
+
+    long maxTick = 0L;
+    for (Event event : events) {
+      scheduler.scheduleAtTick(event, event.key().tick());
+      maxTick = Math.max(maxTick, event.key().tick());
+    }
+
+    Map<Long, List<Event>> fired = new HashMap<>();
+    for (long tick = 0; tick <= maxTick; tick++) {
+      scheduler.drainTick(tick);
+      Event next;
+      while ((next = scheduler.pollMicro()) != null) {
+        fired.computeIfAbsent(tick, ignored -> new ArrayList<>()).add(next);
+        assertTrue(next.key().tick() <= tick, "Event fired before scheduled tick");
+      }
+    }
+
+    assertTrue(fired.containsKey(1L));
+    assertTrue(fired.containsKey(9L));
+    assertTrue(fired.containsKey(17L));
+    assertEquals(1, fired.get(1L).size());
+    assertEquals(1, fired.get(9L).size());
+    assertEquals(1, fired.get(17L).size());
+    assertFalse(scheduler.hasDueAt(18L));
+  }
+}


### PR DESCRIPTION
## Summary
- add event key, payload, and scheduler APIs for two-level ordering
- implement a tick-wheel scheduler with deterministic micro-priority queue and metrics
- cover ordering, determinism, latency, and wheel wrap behaviours with unit tests

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cb353550bc83238a142b83c371a041