### PR TITLE
Implement ShadowWorld overlay

### DIFF
--- a/fabric-stubs/src/main/java/net/minecraft/block/BlockState.java
+++ b/fabric-stubs/src/main/java/net/minecraft/block/BlockState.java
@@ -1,0 +1,42 @@
+package net.minecraft.block;
+
+import java.util.Objects;
+
+/** Simplified representation of a block state for unit testing. */
+public final class BlockState {
+  private final String id;
+
+  public BlockState(String id) {
+    this.id = Objects.requireNonNull(id, "id");
+  }
+
+  public String getId() {
+    return this.id;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof BlockState other)) {
+      return false;
+    }
+    return this.id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.id.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "BlockState{" + this.id + '}';
+  }
+
+  /** Convenience factory mirroring the real game's helper methods. */
+  public static BlockState of(String id) {
+    return new BlockState(id);
+  }
+}

--- a/fabric-stubs/src/main/java/net/minecraft/nbt/NbtCompound.java
+++ b/fabric-stubs/src/main/java/net/minecraft/nbt/NbtCompound.java
@@ -1,0 +1,19 @@
+package net.minecraft.nbt;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Minimal mutable NBT compound supporting copy semantics for tests. */
+public final class NbtCompound extends LinkedHashMap<String, Object> {
+  private static final long serialVersionUID = 1L;
+  public NbtCompound() {}
+
+  private NbtCompound(Map<String, Object> backing) {
+    super(backing);
+  }
+
+  /** Returns a shallow copy of this compound. */
+  public NbtCompound copy() {
+    return new NbtCompound(this);
+  }
+}

--- a/fabric-stubs/src/main/java/net/minecraft/server/world/ServerWorld.java
+++ b/fabric-stubs/src/main/java/net/minecraft/server/world/ServerWorld.java
@@ -1,0 +1,21 @@
+package net.minecraft.server.world;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+/** Minimal stub for Minecraft's {@code ServerWorld}. */
+public abstract class ServerWorld extends World {
+  public abstract BlockState getBlockState(BlockPos pos);
+
+  public abstract boolean setBlockState(BlockPos pos, BlockState state, int flags);
+
+  public NbtCompound getBlockEntityNbt(BlockPos pos) {
+    return null;
+  }
+
+  public void setBlockEntityNbt(BlockPos pos, NbtCompound nbt) {}
+
+  public void removeBlockEntity(BlockPos pos) {}
+}

--- a/fabric-stubs/src/main/java/net/minecraft/util/math/BlockPos.java
+++ b/fabric-stubs/src/main/java/net/minecraft/util/math/BlockPos.java
@@ -1,0 +1,65 @@
+package net.minecraft.util.math;
+
+import java.util.Objects;
+
+/** Minimal immutable block position used by tests and engine stubs. */
+public final class BlockPos {
+  private final int x;
+  private final int y;
+  private final int z;
+
+  public BlockPos(int x, int y, int z) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  public int getX() {
+    return this.x;
+  }
+
+  public int getY() {
+    return this.y;
+  }
+
+  public int getZ() {
+    return this.z;
+  }
+
+  /** Returns a new position offset by the given direction. */
+  public BlockPos offset(Direction direction) {
+    return new BlockPos(
+        this.x + direction.getOffsetX(),
+        this.y + direction.getOffsetY(),
+        this.z + direction.getOffsetZ());
+  }
+
+  /** Returns a new position translated by the specified delta on each axis. */
+  public BlockPos add(int dx, int dy, int dz) {
+    if (dx == 0 && dy == 0 && dz == 0) {
+      return this;
+    }
+    return new BlockPos(this.x + dx, this.y + dy, this.z + dz);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof BlockPos other)) {
+      return false;
+    }
+    return this.x == other.x && this.y == other.y && this.z == other.z;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.x, this.y, this.z);
+  }
+
+  @Override
+  public String toString() {
+    return "BlockPos{" + "x=" + this.x + ", y=" + this.y + ", z=" + this.z + '}';
+  }
+}

--- a/fabric-stubs/src/main/java/net/minecraft/util/math/Direction.java
+++ b/fabric-stubs/src/main/java/net/minecraft/util/math/Direction.java
@@ -1,0 +1,45 @@
+package net.minecraft.util.math;
+
+/** Minimal subset of Minecraft's {@code Direction} enum. */
+public enum Direction {
+  DOWN(0, -1, 0),
+  UP(0, 1, 0),
+  NORTH(0, 0, -1),
+  SOUTH(0, 0, 1),
+  WEST(-1, 0, 0),
+  EAST(1, 0, 0);
+
+  private final int offsetX;
+  private final int offsetY;
+  private final int offsetZ;
+
+  Direction(int offsetX, int offsetY, int offsetZ) {
+    this.offsetX = offsetX;
+    this.offsetY = offsetY;
+    this.offsetZ = offsetZ;
+  }
+
+  public int getOffsetX() {
+    return this.offsetX;
+  }
+
+  public int getOffsetY() {
+    return this.offsetY;
+  }
+
+  public int getOffsetZ() {
+    return this.offsetZ;
+  }
+
+  /** Returns the opposite direction. */
+  public Direction getOpposite() {
+    return switch (this) {
+      case DOWN -> UP;
+      case UP -> DOWN;
+      case NORTH -> SOUTH;
+      case SOUTH -> NORTH;
+      case WEST -> EAST;
+      case EAST -> WEST;
+    };
+  }
+}

--- a/fabric-stubs/src/main/java/net/minecraft/world/World.java
+++ b/fabric-stubs/src/main/java/net/minecraft/world/World.java
@@ -1,0 +1,9 @@
+package net.minecraft.world;
+
+/**
+ * Extremely small subset of {@code World} required by the shadow world implementation.
+ */
+public abstract class World {
+  public static final int NO_NEIGHBOR_UPDATES = 1 << 0;
+  public static final int NO_LIGHTING = 1 << 1;
+}

--- a/fast-quartz-core/build.gradle.kts
+++ b/fast-quartz-core/build.gradle.kts
@@ -8,6 +8,7 @@ base {
 
 dependencies {
     api(project(":fabric-stubs"))
+    implementation("it.unimi.dsi:fastutil:8.5.13")
     implementation("org.slf4j:slf4j-api:2.0.13")
     testRuntimeOnly("org.slf4j:slf4j-simple:2.0.13")
 }

--- a/fast-quartz-core/gradle.lockfile
+++ b/fast-quartz-core/gradle.lockfile
@@ -21,6 +21,7 @@ com.google.protobuf:protobuf-java:3.19.6=annotationProcessor,testAnnotationProce
 io.github.eisop:dataflow-errorprone:3.41.0-eisop1=annotationProcessor,testAnnotationProcessor
 io.github.java-diff-utils:java-diff-utils:4.12=annotationProcessor,testAnnotationProcessor
 javax.inject:javax.inject:1=annotationProcessor,testAnnotationProcessor
+it.unimi.dsi:fastutil:8.5.13=compileClasspath,testCompileClasspath,testRuntimeClasspath
 org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
 org.checkerframework:checker-qual:3.33.0=annotationProcessor,testAnnotationProcessor
 org.junit.jupiter:junit-jupiter-api:5.10.2=testCompileClasspath,testRuntimeClasspath

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/shadow/CommitPolicy.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/shadow/CommitPolicy.java
@@ -1,0 +1,7 @@
+package dev.fastquartz.fastquartz.engine.shadow;
+
+/** Policy hints for shadow world commits. */
+public enum CommitPolicy {
+  /** Apply states silently without triggering vanilla neighbour recursion or lighting. */
+  SILENT_NO_PHYSICS
+}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/shadow/SectionDelta.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/shadow/SectionDelta.java
@@ -1,0 +1,66 @@
+package dev.fastquartz.fastquartz.engine.shadow;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.shorts.ShortArrayList;
+import net.minecraft.block.BlockState;
+import net.minecraft.nbt.NbtCompound;
+
+/** Sparse mutation list for a chunk section (16×16×16 blocks). */
+final class SectionDelta {
+  final ShortArrayList indices = new ShortArrayList();
+  final ObjectArrayList<BlockState> states = new ObjectArrayList<>();
+  final ObjectArrayList<NbtCompound> blockEntityNbt = new ObjectArrayList<>();
+
+  int size() {
+    return this.indices.size();
+  }
+
+  short indexAt(int slot) {
+    return this.indices.getShort(slot);
+  }
+
+  BlockState stateAt(int slot) {
+    return this.states.get(slot);
+  }
+
+  NbtCompound blockEntityNbtAt(int slot) {
+    return this.blockEntityNbt.get(slot);
+  }
+
+  void put(short localIndex, BlockState state, NbtCompound nbt) {
+    int slot = findSlot(localIndex);
+    if (slot >= 0) {
+      this.states.set(slot, state);
+      this.blockEntityNbt.set(slot, nbt);
+      return;
+    }
+    this.indices.add(localIndex);
+    this.states.add(state);
+    this.blockEntityNbt.add(nbt);
+  }
+
+  BlockState get(short localIndex) {
+    int slot = findSlot(localIndex);
+    if (slot < 0) {
+      return null;
+    }
+    return this.states.get(slot);
+  }
+
+  NbtCompound getBlockEntityNbt(short localIndex) {
+    int slot = findSlot(localIndex);
+    if (slot < 0) {
+      return null;
+    }
+    return this.blockEntityNbt.get(slot);
+  }
+
+  private int findSlot(short localIndex) {
+    for (int i = 0; i < this.indices.size(); i++) {
+      if (this.indices.getShort(i) == localIndex) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/shadow/Shadow.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/shadow/Shadow.java
@@ -1,0 +1,25 @@
+package dev.fastquartz.fastquartz.engine.shadow;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+
+/** Overlay view that buffers block mutations before atomically committing them. */
+public interface Shadow {
+  /** Returns the staged state at {@code pos}, falling back to the live world if untouched. */
+  BlockState get(BlockPos pos);
+
+  /** Stages a block state (and optional block-entity data) to be written on commit. */
+  void set(BlockPos pos, BlockState state, NbtCompound blockEntityNbt);
+
+  /** Records that {@code src} notified its neighbour along {@code dir}. */
+  void captureNeighbor(BlockPos src, Direction dir);
+
+  /** Drops all staged state without mutating the backing world. */
+  void clear();
+
+  /** Applies the staged state to {@code world} according to {@code policy}. */
+  ShadowCommitStats commit(ServerWorld world, CommitPolicy policy);
+}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/shadow/ShadowCommitStats.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/shadow/ShadowCommitStats.java
@@ -1,0 +1,24 @@
+package dev.fastquartz.fastquartz.engine.shadow;
+
+import java.util.List;
+import java.util.Objects;
+import net.minecraft.util.math.BlockPos;
+
+/** Result produced by {@link Shadow#commit(ServerWorld, CommitPolicy)}. */
+public final class ShadowCommitStats {
+  private final int blocksApplied;
+  private final List<BlockPos> neighborChanges;
+
+  public ShadowCommitStats(int blocksApplied, List<BlockPos> neighborChanges) {
+    this.blocksApplied = blocksApplied;
+    this.neighborChanges = List.copyOf(Objects.requireNonNull(neighborChanges, "neighborChanges"));
+  }
+
+  public int blocksApplied() {
+    return this.blocksApplied;
+  }
+
+  public List<BlockPos> neighborChanges() {
+    return this.neighborChanges;
+  }
+}

--- a/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/shadow/ShadowWorld.java
+++ b/fast-quartz-core/src/main/java/dev/fastquartz/fastquartz/engine/shadow/ShadowWorld.java
@@ -1,0 +1,246 @@
+package dev.fastquartz.fastquartz.engine.shadow;
+
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectList;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Objects;
+import net.minecraft.block.BlockState;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+
+/** Sparse write log that overlays block mutations on top of a live world. */
+public final class ShadowWorld implements Shadow {
+  private static final int SILENT_FLAGS = World.NO_NEIGHBOR_UPDATES | World.NO_LIGHTING;
+  private static final int SECTION_SIZE = 16;
+  private static final int LOCAL_MASK = SECTION_SIZE - 1;
+  private static final int SECTION_Y_BITS = 20;
+  private static final int CHUNK_COORD_BITS = 22;
+  private static final int CHUNK_Z_SHIFT = SECTION_Y_BITS;
+  private static final int CHUNK_X_SHIFT = CHUNK_Z_SHIFT + CHUNK_COORD_BITS;
+  private static final long SECTION_Y_MASK = (1L << SECTION_Y_BITS) - 1L;
+  private static final long CHUNK_COORD_MASK = (1L << CHUNK_COORD_BITS) - 1L;
+
+  private final ServerWorld world;
+  private final Long2ObjectOpenHashMap<SectionDelta> deltas = new Long2ObjectOpenHashMap<>();
+  private final ObjectArrayList<BlockPos> neighborQueue = new ObjectArrayList<>();
+  private final BitSet touchedChunks = new BitSet();
+  private final LongArrayList touchedChunkKeys = new LongArrayList();
+  private final Long2IntOpenHashMap chunkIndex = new Long2IntOpenHashMap();
+
+  public ShadowWorld(ServerWorld world) {
+    this.world = Objects.requireNonNull(world, "world");
+    this.chunkIndex.defaultReturnValue(-1);
+  }
+
+  @Override
+  public BlockState get(BlockPos pos) {
+    Objects.requireNonNull(pos, "pos");
+    long sectionKey = packSectionKey(pos);
+    SectionDelta delta = this.deltas.get(sectionKey);
+    if (delta != null) {
+      short localIndex = computeLocalIndex(pos);
+      BlockState staged = delta.get(localIndex);
+      if (staged != null) {
+        return staged;
+      }
+    }
+    return this.world.getBlockState(pos);
+  }
+
+  @Override
+  public void set(BlockPos pos, BlockState state, NbtCompound blockEntityNbt) {
+    Objects.requireNonNull(pos, "pos");
+    Objects.requireNonNull(state, "state");
+    long sectionKey = packSectionKey(pos);
+    SectionDelta delta = this.deltas.computeIfAbsent(sectionKey, ignored -> new SectionDelta());
+    short localIndex = computeLocalIndex(pos);
+    NbtCompound nbtCopy = blockEntityNbt != null ? blockEntityNbt.copy() : null;
+    delta.put(localIndex, state, nbtCopy);
+
+    int chunkX = pos.getX() >> 4;
+    int chunkZ = pos.getZ() >> 4;
+    markChunkTouched(chunkX, chunkZ);
+  }
+
+  @Override
+  public void captureNeighbor(BlockPos src, Direction dir) {
+    Objects.requireNonNull(src, "src");
+    Objects.requireNonNull(dir, "dir");
+    this.neighborQueue.add(src.offset(dir));
+  }
+
+  @Override
+  public void clear() {
+    this.deltas.clear();
+    this.neighborQueue.clear();
+    this.touchedChunks.clear();
+    this.touchedChunkKeys.clear();
+    this.chunkIndex.clear();
+    this.chunkIndex.defaultReturnValue(-1);
+  }
+
+  @Override
+  public ShadowCommitStats commit(ServerWorld world, CommitPolicy policy) {
+    Objects.requireNonNull(world, "world");
+    Objects.requireNonNull(policy, "policy");
+    if (world != this.world) {
+      throw new IllegalArgumentException("commit world does not match shadow base world");
+    }
+    if (policy != CommitPolicy.SILENT_NO_PHYSICS) {
+      throw new UnsupportedOperationException("Unsupported commit policy: " + policy);
+    }
+
+    List<BlockMutation> mutations = collectMutations(world);
+    List<BlockPos> neighborsSnapshot = List.copyOf(this.neighborQueue);
+    if (mutations.isEmpty() && neighborsSnapshot.isEmpty()) {
+      clear();
+      return new ShadowCommitStats(0, neighborsSnapshot);
+    }
+
+    List<BlockMutation> applied = new ArrayList<>(mutations.size());
+    try {
+      for (BlockMutation mutation : mutations) {
+        world.setBlockState(mutation.pos, mutation.newState, SILENT_FLAGS);
+        if (mutation.newBlockEntityNbt != null) {
+          world.setBlockEntityNbt(mutation.pos, mutation.newBlockEntityNbt.copy());
+        } else if (mutation.previousBlockEntityNbt != null) {
+          world.removeBlockEntity(mutation.pos);
+        }
+        applied.add(mutation);
+      }
+    } catch (RuntimeException failure) {
+      rollback(world, applied);
+      clear();
+      throw failure;
+    }
+
+    clear();
+    return new ShadowCommitStats(applied.size(), neighborsSnapshot);
+  }
+
+  private List<BlockMutation> collectMutations(ServerWorld world) {
+    ObjectList<BlockMutation> mutations = new ObjectArrayList<>();
+    for (Long2ObjectMap.Entry<SectionDelta> entry : this.deltas.long2ObjectEntrySet()) {
+      long sectionKey = entry.getLongKey();
+      SectionDelta delta = entry.getValue();
+      int chunkX = unpackChunkX(sectionKey);
+      int sectionY = unpackSectionY(sectionKey);
+      int chunkZ = unpackChunkZ(sectionKey);
+      for (int i = 0; i < delta.size(); i++) {
+        short localIndex = delta.indexAt(i);
+        BlockPos pos = toWorldPos(chunkX, sectionY, chunkZ, localIndex);
+        BlockState newState = delta.stateAt(i);
+        BlockState previousState = world.getBlockState(pos);
+        NbtCompound previousNbt = world.getBlockEntityNbt(pos);
+        if (previousNbt != null) {
+          previousNbt = previousNbt.copy();
+        }
+        NbtCompound stagedNbt = delta.blockEntityNbtAt(i);
+        if (stagedNbt != null) {
+          stagedNbt = stagedNbt.copy();
+        }
+        mutations.add(new BlockMutation(pos, previousState, previousNbt, newState, stagedNbt));
+      }
+    }
+    return mutations;
+  }
+
+  private void rollback(ServerWorld world, List<BlockMutation> applied) {
+    for (int i = applied.size() - 1; i >= 0; i--) {
+      BlockMutation mutation = applied.get(i);
+      world.setBlockState(mutation.pos, mutation.previousState, SILENT_FLAGS);
+      if (mutation.previousBlockEntityNbt != null) {
+        world.setBlockEntityNbt(mutation.pos, mutation.previousBlockEntityNbt.copy());
+      } else {
+        world.removeBlockEntity(mutation.pos);
+      }
+    }
+  }
+
+  private void markChunkTouched(int chunkX, int chunkZ) {
+    long chunkKey = packChunkKey(chunkX, chunkZ);
+    int slot = this.chunkIndex.get(chunkKey);
+    if (slot < 0) {
+      slot = this.touchedChunkKeys.size();
+      this.chunkIndex.put(chunkKey, slot);
+      this.touchedChunkKeys.add(chunkKey);
+    }
+    this.touchedChunks.set(slot);
+  }
+
+  private static BlockPos toWorldPos(int chunkX, int sectionY, int chunkZ, short localIndex) {
+    int localX = localIndex & LOCAL_MASK;
+    int localZ = (localIndex >>> 4) & LOCAL_MASK;
+    int localY = (localIndex >>> 8) & LOCAL_MASK;
+    int x = (chunkX << 4) | localX;
+    int y = (sectionY << 4) | localY;
+    int z = (chunkZ << 4) | localZ;
+    return new BlockPos(x, y, z);
+  }
+
+  private static short computeLocalIndex(BlockPos pos) {
+    int localX = pos.getX() & LOCAL_MASK;
+    int localY = pos.getY() & LOCAL_MASK;
+    int localZ = pos.getZ() & LOCAL_MASK;
+    return (short) ((localY << 8) | (localZ << 4) | localX);
+  }
+
+  private static long packSectionKey(BlockPos pos) {
+    int chunkX = pos.getX() >> 4;
+    int chunkZ = pos.getZ() >> 4;
+    int sectionY = pos.getY() >> 4;
+    return packSectionKey(chunkX, chunkZ, sectionY);
+  }
+
+  private static long packSectionKey(int chunkX, int chunkZ, int sectionY) {
+    long packedX = asUnsigned(chunkX, CHUNK_COORD_BITS) << CHUNK_X_SHIFT;
+    long packedZ = asUnsigned(chunkZ, CHUNK_COORD_BITS) << CHUNK_Z_SHIFT;
+    long packedY = asUnsigned(sectionY, SECTION_Y_BITS);
+    return packedX | packedZ | packedY;
+  }
+
+  private static long packChunkKey(int chunkX, int chunkZ) {
+    return (((long) chunkX) << 32) ^ (chunkZ & 0xffffffffL);
+  }
+
+  private static long asUnsigned(int value, int bits) {
+    long mask = (1L << bits) - 1L;
+    return ((long) value) & mask;
+  }
+
+  private static int unpackChunkX(long sectionKey) {
+    long value = (sectionKey >> CHUNK_X_SHIFT) & CHUNK_COORD_MASK;
+    return decodeSigned(value, CHUNK_COORD_BITS);
+  }
+
+  private static int unpackChunkZ(long sectionKey) {
+    long value = (sectionKey >> CHUNK_Z_SHIFT) & CHUNK_COORD_MASK;
+    return decodeSigned(value, CHUNK_COORD_BITS);
+  }
+
+  private static int unpackSectionY(long sectionKey) {
+    long value = sectionKey & SECTION_Y_MASK;
+    return decodeSigned(value, SECTION_Y_BITS);
+  }
+
+  private static int decodeSigned(long value, int bits) {
+    long shift = 64L - bits;
+    return (int) ((value << shift) >> shift);
+  }
+
+  private record BlockMutation(
+      BlockPos pos,
+      BlockState previousState,
+      NbtCompound previousBlockEntityNbt,
+      BlockState newState,
+      NbtCompound newBlockEntityNbt) {}
+}

--- a/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/shadow/ShadowWorldTest.java
+++ b/fast-quartz-core/src/test/java/dev/fastquartz/fastquartz/engine/shadow/ShadowWorldTest.java
@@ -1,0 +1,163 @@
+package dev.fastquartz.fastquartz.engine.shadow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.block.BlockState;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import org.junit.jupiter.api.Test;
+
+class ShadowWorldTest {
+  private static final BlockState AIR = BlockState.of("minecraft:air");
+  private static final BlockState STONE = BlockState.of("minecraft:stone");
+  private static final BlockState DIRT = BlockState.of("minecraft:dirt");
+  private static final BlockState GOLD = BlockState.of("minecraft:gold_block");
+
+  @Test
+  void commitAppliesAllStagedChangesAtomically() {
+    FakeServerWorld world = new FakeServerWorld();
+    BlockPos first = new BlockPos(0, 64, 0);
+    BlockPos second = new BlockPos(1, 64, 0);
+    world.prime(first, AIR);
+    world.prime(second, AIR);
+
+    ShadowWorld shadow = new ShadowWorld(world);
+    shadow.set(first, STONE, null);
+    shadow.set(second, DIRT, null);
+
+    assertEquals(AIR, world.getBlockState(first));
+    assertEquals(STONE, shadow.get(first));
+
+    ShadowCommitStats stats = shadow.commit(world, CommitPolicy.SILENT_NO_PHYSICS);
+    assertEquals(2, stats.blocksApplied());
+    assertTrue(stats.neighborChanges().isEmpty());
+    assertEquals(STONE, world.getBlockState(first));
+    assertEquals(DIRT, world.getBlockState(second));
+
+    ShadowCommitStats repeat = shadow.commit(world, CommitPolicy.SILENT_NO_PHYSICS);
+    assertEquals(0, repeat.blocksApplied());
+    assertTrue(repeat.neighborChanges().isEmpty());
+  }
+
+  @Test
+  void neighborCaptureQueuesWithoutVanillaRecursion() {
+    FakeServerWorld world = new FakeServerWorld();
+    ShadowWorld shadow = new ShadowWorld(world);
+    BlockPos origin = new BlockPos(0, 70, 0);
+    BlockPos neighbor = origin.offset(Direction.NORTH);
+
+    shadow.set(origin, STONE, null);
+    shadow.captureNeighbor(origin, Direction.NORTH);
+
+    ShadowCommitStats stats = shadow.commit(world, CommitPolicy.SILENT_NO_PHYSICS);
+    assertEquals(1, stats.blocksApplied());
+    assertEquals(List.of(neighbor), stats.neighborChanges());
+    assertEquals(World.NO_NEIGHBOR_UPDATES | World.NO_LIGHTING, world.lastFlags());
+  }
+
+  @Test
+  void rollbackRestoresPreviousStateOnFailure() {
+    FakeServerWorld world = new FakeServerWorld();
+    BlockPos first = new BlockPos(4, 65, 4);
+    BlockPos second = new BlockPos(5, 65, 4);
+    world.prime(first, AIR);
+    world.prime(second, AIR);
+
+    ShadowWorld shadow = new ShadowWorld(world);
+    shadow.set(first, STONE, null);
+    shadow.set(second, DIRT, null);
+    world.failOn(second);
+
+    assertThrows(
+        RuntimeException.class, () -> shadow.commit(world, CommitPolicy.SILENT_NO_PHYSICS));
+    assertEquals(AIR, world.getBlockState(first));
+    assertEquals(AIR, world.getBlockState(second));
+
+    ShadowCommitStats stats = shadow.commit(world, CommitPolicy.SILENT_NO_PHYSICS);
+    assertEquals(0, stats.blocksApplied());
+    assertTrue(stats.neighborChanges().isEmpty());
+  }
+
+  @Test
+  void commitPropagatesBlockEntityDataWithCopySemantics() {
+    FakeServerWorld world = new FakeServerWorld();
+    ShadowWorld shadow = new ShadowWorld(world);
+    BlockPos beacon = new BlockPos(8, 72, 8);
+
+    NbtCompound nbt = new NbtCompound();
+    nbt.put("level", 5);
+    shadow.set(beacon, GOLD, nbt);
+    nbt.put("level", 1); // mutate after staging; shadow should keep the original copy.
+
+    ShadowCommitStats stats = shadow.commit(world, CommitPolicy.SILENT_NO_PHYSICS);
+    assertEquals(1, stats.blocksApplied());
+    assertTrue(stats.neighborChanges().isEmpty());
+
+    NbtCompound stored = world.blockEntity(beacon);
+    assertNotNull(stored);
+    assertEquals(5, stored.get("level"));
+  }
+
+  private static final class FakeServerWorld extends ServerWorld {
+    private final Map<BlockPos, BlockState> states = new HashMap<>();
+    private final Map<BlockPos, NbtCompound> blockEntities = new HashMap<>();
+    private BlockPos failOn;
+    private int lastFlags = 0;
+
+    @Override
+    public BlockState getBlockState(BlockPos pos) {
+      return this.states.getOrDefault(pos, AIR);
+    }
+
+    @Override
+    public boolean setBlockState(BlockPos pos, BlockState state, int flags) {
+      if (pos.equals(this.failOn)) {
+        throw new RuntimeException("Injected failure");
+      }
+      this.lastFlags = flags;
+      this.states.put(pos, state);
+      return true;
+    }
+
+    @Override
+    public NbtCompound getBlockEntityNbt(BlockPos pos) {
+      NbtCompound nbt = this.blockEntities.get(pos);
+      return nbt == null ? null : nbt.copy();
+    }
+
+    @Override
+    public void setBlockEntityNbt(BlockPos pos, NbtCompound nbt) {
+      this.blockEntities.put(pos, nbt.copy());
+    }
+
+    @Override
+    public void removeBlockEntity(BlockPos pos) {
+      this.blockEntities.remove(pos);
+    }
+
+    void prime(BlockPos pos, BlockState state) {
+      this.states.put(pos, state);
+    }
+
+    void failOn(BlockPos pos) {
+      this.failOn = pos;
+    }
+
+    int lastFlags() {
+      return this.lastFlags;
+    }
+
+    NbtCompound blockEntity(BlockPos pos) {
+      return this.blockEntities.get(pos);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal Minecraft stubs for block positions, directions, world flags, and server world interactions needed for staging
- implement the Shadow API with a SectionDelta-backed ShadowWorld that stages mutations, captures neighbor notifications, and commits atomically with rollback on failure
- extend coverage with ShadowWorld tests exercising atomic commits, neighbor capture, rollback behaviour, and block-entity NBT handling

## Testing
- `./gradlew fast-quartz-core:test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68cb3a8ace008323b663139bf5245fc8