### PR TITLE
Apply Fabric Loom and real Minecraft dependencies

### DIFF
--- a/fast-quartz-core/build.gradle.kts
+++ b/fast-quartz-core/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("fabric-loom")
     `java-library`
 }
 
@@ -7,7 +8,11 @@ base {
 }
 
 dependencies {
-    api(project(":fabric-stubs"))
+    minecraft("com.mojang:minecraft:1.20.1")
+    mappings("net.fabricmc:yarn:1.20.1+build.10:v2")
+    modImplementation("net.fabricmc:fabric-loader:0.15.11")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.91.0+1.20.1")
+
     implementation("it.unimi.dsi:fastutil:8.5.13")
     implementation("org.slf4j:slf4j-api:2.0.13")
     testRuntimeOnly("org.slf4j:slf4j-simple:2.0.13")

--- a/headless-runner/build.gradle.kts
+++ b/headless-runner/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("fabric-loom")
     application
 }
 
@@ -7,12 +8,24 @@ base {
 }
 
 dependencies {
-    implementation(project(":fabric-stubs"))
-    implementation(project(":fast-quartz-core"))
+    minecraft("com.mojang:minecraft:1.20.1")
+    mappings("net.fabricmc:yarn:1.20.1+build.10:v2")
+    modImplementation("net.fabricmc:fabric-loader:0.15.11")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.91.0+1.20.1")
+
+    modImplementation(project(":fast-quartz-core"))
     implementation("org.slf4j:slf4j-api:2.0.13")
     runtimeOnly("org.slf4j:slf4j-simple:2.0.13")
 }
 
 application {
     mainClass.set("dev.fastquartz.headless.HeadlessServerLauncher")
+}
+
+loom {
+    runs {
+        configureEach {
+            ideConfigGenerated(false)
+        }
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,6 @@
 pluginManagement {
+    val loomVersion = "1.5-SNAPSHOT"
+
     repositories {
         gradlePluginPortal()
         mavenCentral()
@@ -8,6 +10,15 @@ pluginManagement {
         id("com.diffplug.spotless") version "6.25.0"
         id("net.ltgt.errorprone") version "3.1.0"
         id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+        id("fabric-loom") version loomVersion
+    }
+
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "fabric-loom") {
+                useModule("net.fabricmc:fabric-loom:$loomVersion")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- enable Fabric Loom on `fast-quartz-core` and wire it to Minecraft 1.20.1, Yarn build 10, loader 0.15.11, and Fabric API so intermediary remapping can run
- mirror the Loom setup for `headless-runner`, depending on the remapped core module and suppressing generated run configurations
- configure plugin management to resolve the Fabric Loom 1.5-SNAPSHOT plugin from the Fabric maven repository

## Testing
- `./gradlew build` *(fails: proxy blocks downloads from maven.fabricmc.net)*

------
https://chatgpt.com/codex/tasks/task_e_68cc53e7aad483239774af283dc7428e