### PR TITLE
Implement deterministic event queue with timing wheel

### DIFF
--- a/engine/src/main/java/dev/fastquartz/engine/event/EventKey.java
+++ b/engine/src/main/java/dev/fastquartz/engine/event/EventKey.java
@@ -1,0 +1,88 @@
+package dev.fastquartz.engine.event;
+
+import java.util.Objects;
+
+/** Lexicographically ordered event key: (tick, micro, region, local order). */
+public record EventKey(long tick, int micro, int regionId, long localOrder)
+    implements Comparable<EventKey> {
+  private static final int MICRO_MIN = 0;
+  private static final int MICRO_MAX = 9;
+
+  private static final int EVENT_TYPE_BITS = 4;
+  private static final int X_BITS = 16;
+  private static final int Z_BITS = 20;
+  private static final int Y_BITS = 20;
+  private static final int X_SHIFT = EVENT_TYPE_BITS;
+  private static final int Z_SHIFT = X_SHIFT + X_BITS; // matches (x << 4) / (z << 20)
+  private static final int Y_SHIFT = Z_SHIFT + Z_BITS;
+  private static final long X_MASK = (1L << X_BITS) - 1;
+  private static final long Z_MASK = (1L << Z_BITS) - 1;
+  private static final long Y_MASK = (1L << Y_BITS) - 1;
+  private static final long EVENT_MASK = (1L << EVENT_TYPE_BITS) - 1;
+
+  public EventKey {
+    if (tick < 0) {
+      throw new IllegalArgumentException("tick must be non-negative");
+    }
+    if (micro < MICRO_MIN || micro > MICRO_MAX) {
+      throw new IllegalArgumentException("micro out of range: " + micro);
+    }
+    if (localOrder < 0) {
+      throw new IllegalArgumentException("localOrder must be non-negative");
+    }
+  }
+
+  /** Convenience factory mirroring the canonical record constructor. */
+  public static EventKey of(long tick, int micro, int regionId, long localOrder) {
+    return new EventKey(tick, micro, regionId, localOrder);
+  }
+
+  /**
+   * Packs block coordinates and the locked event ordinal into the {@code localOrder} lane. The
+   * layout matches the spec: {@code (y << 40) | (z << 20) | (x << 4) | eventTypeOrdinal}.
+   */
+  public static long packLocalOrder(int x, int y, int z, EventType type) {
+    Objects.requireNonNull(type, "type");
+    checkCoordinate("x", x, X_MASK);
+    checkCoordinate("y", y, Y_MASK);
+    checkCoordinate("z", z, Z_MASK);
+    int ordinal = type.eventOrdinal();
+    if ((ordinal & ~EVENT_MASK) != 0) {
+      throw new IllegalArgumentException("event ordinal does not fit: " + ordinal);
+    }
+    return (((long) y & Y_MASK) << Y_SHIFT)
+        | (((long) z & Z_MASK) << Z_SHIFT)
+        | (((long) x & X_MASK) << X_SHIFT)
+        | ordinal;
+  }
+
+  /** Creates an event key by deriving the local order from block coordinates and event type. */
+  public static EventKey forBlock(
+      long tick, int micro, int regionId, int x, int y, int z, EventType type) {
+    return new EventKey(tick, micro, regionId, packLocalOrder(x, y, z, type));
+  }
+
+  private static void checkCoordinate(String axis, int value, long mask) {
+    if (value < 0 || (((long) value) & ~mask) != 0) {
+      throw new IllegalArgumentException(axis + " coordinate out of range: " + value);
+    }
+  }
+
+  @Override
+  public int compareTo(EventKey other) {
+    Objects.requireNonNull(other, "other");
+    int cmp = Long.compare(tick, other.tick);
+    if (cmp != 0) {
+      return cmp;
+    }
+    cmp = Integer.compare(micro, other.micro);
+    if (cmp != 0) {
+      return cmp;
+    }
+    cmp = Integer.compare(regionId, other.regionId);
+    if (cmp != 0) {
+      return cmp;
+    }
+    return Long.compareUnsigned(localOrder, other.localOrder);
+  }
+}

--- a/engine/src/main/java/dev/fastquartz/engine/event/EventQueue.java
+++ b/engine/src/main/java/dev/fastquartz/engine/event/EventQueue.java
@@ -1,0 +1,260 @@
+package dev.fastquartz.engine.event;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.function.Consumer;
+
+/**
+ * Deterministic event queue with a hierarchical timing wheel. Events are ordered lexicographically
+ * by {@link EventKey}. Within identical keys, insertion order is preserved.
+ */
+public final class EventQueue<T> {
+  private final Queue<ScheduledEvent<T>> readyQueue = new PriorityQueue<>();
+  private final TimingWheel<T> timingWheel;
+  private long sequenceCounter;
+  private long activeTick = Long.MIN_VALUE;
+
+  /** Creates a queue starting at tick zero. */
+  public EventQueue() {
+    this(0L);
+  }
+
+  public EventQueue(long startTick) {
+    if (startTick < 0) {
+      throw new IllegalArgumentException("startTick must be non-negative");
+    }
+    this.timingWheel = new TimingWheel<>(startTick);
+  }
+
+  /** Schedules an event for delivery based on its key. */
+  public void schedule(EventKey key, T payload) {
+    Objects.requireNonNull(key, "key");
+    ScheduledEvent<T> event = new ScheduledEvent<>(key, payload, sequenceCounter++);
+    if (activeTick != Long.MIN_VALUE && key.tick() < activeTick) {
+      throw new IllegalArgumentException("Cannot schedule event in the past: " + key);
+    }
+    if (activeTick != Long.MIN_VALUE && key.tick() == activeTick) {
+      readyQueue.add(event);
+    } else {
+      timingWheel.schedule(event);
+    }
+  }
+
+  /** Returns {@code true} if no events remain either in the ready queue or timing wheel. */
+  public boolean isEmpty() {
+    return readyQueue.isEmpty() && timingWheel.isEmpty();
+  }
+
+  /** Clears all pending events and rewinds the timing wheel to its start tick. */
+  public void clear() {
+    readyQueue.clear();
+    timingWheel.clear();
+    activeTick = Long.MIN_VALUE;
+    sequenceCounter = 0L;
+  }
+
+  /** Retrieves and removes the next event according to the deterministic ordering. */
+  public Event<T> poll() {
+    if (!ensureReady()) {
+      return null;
+    }
+    ScheduledEvent<T> scheduled = readyQueue.poll();
+    if (scheduled == null) {
+      return null;
+    }
+    activeTick = scheduled.key().tick();
+    return scheduled.toEvent();
+  }
+
+  private boolean ensureReady() {
+    if (!readyQueue.isEmpty()) {
+      return true;
+    }
+    while (readyQueue.isEmpty()) {
+      long nextTick = timingWheel.nextTick();
+      if (nextTick == Long.MAX_VALUE) {
+        activeTick = Long.MIN_VALUE;
+        return false;
+      }
+      if (activeTick != Long.MIN_VALUE && nextTick < activeTick) {
+        throw new IllegalStateException(
+            "Timing wheel produced non-monotonic tick: " + nextTick + " < " + activeTick);
+      }
+      timingWheel.collectTick(nextTick, readyQueue::add);
+      activeTick = nextTick;
+    }
+    return true;
+  }
+
+  /** Immutable view of a dequeued event. */
+  public static final class Event<T> {
+    private final EventKey key;
+    private final T payload;
+
+    public Event(EventKey key, T payload) {
+      this.key = Objects.requireNonNull(key, "key");
+      this.payload = payload;
+    }
+
+    public EventKey key() {
+      return key;
+    }
+
+    public T payload() {
+      return payload;
+    }
+  }
+
+  private static final class ScheduledEvent<T> implements Comparable<ScheduledEvent<T>> {
+    private final EventKey key;
+    private final T payload;
+    private final long sequence;
+
+    ScheduledEvent(EventKey key, T payload, long sequence) {
+      this.key = Objects.requireNonNull(key, "key");
+      this.payload = payload;
+      this.sequence = sequence;
+    }
+
+    Event<T> toEvent() {
+      return new Event<>(key, payload);
+    }
+
+    EventKey key() {
+      return key;
+    }
+
+    @Override
+    public int compareTo(ScheduledEvent<T> other) {
+      int cmp = key.compareTo(other.key);
+      if (cmp != 0) {
+        return cmp;
+      }
+      return Long.compare(sequence, other.sequence);
+    }
+  }
+
+  private static final class TimingWheel<T> {
+    private static final int LEVEL_BITS = 4;
+    private static final int WHEEL_SIZE = 1 << LEVEL_BITS; // 16 slots per tier.
+    private static final int LEVEL_COUNT = 8;
+    private static final int WHEEL_MASK = WHEEL_SIZE - 1;
+
+    private final List<List<ArrayDeque<ScheduledEvent<T>>>> levels = new ArrayList<>(LEVEL_COUNT);
+    private final long startTick;
+    private long cursor;
+
+    TimingWheel(long startTick) {
+      this.startTick = startTick;
+      this.cursor = startTick;
+      for (int level = 0; level < LEVEL_COUNT; level++) {
+        ArrayList<ArrayDeque<ScheduledEvent<T>>> slots = new ArrayList<>(WHEEL_SIZE);
+        for (int slot = 0; slot < WHEEL_SIZE; slot++) {
+          slots.add(new ArrayDeque<>());
+        }
+        levels.add(slots);
+      }
+    }
+
+    void schedule(ScheduledEvent<T> event) {
+      long tick = event.key().tick();
+      if (tick < cursor) {
+        throw new IllegalArgumentException("tick " + tick + " < cursor " + cursor);
+      }
+      int level = selectLevel(tick);
+      enqueue(level, event);
+    }
+
+    boolean isEmpty() {
+      for (List<ArrayDeque<ScheduledEvent<T>>> level : levels) {
+        for (ArrayDeque<ScheduledEvent<T>> bucket : level) {
+          if (!bucket.isEmpty()) {
+            return false;
+          }
+        }
+      }
+      return true;
+    }
+
+    void clear() {
+      for (List<ArrayDeque<ScheduledEvent<T>>> level : levels) {
+        for (ArrayDeque<ScheduledEvent<T>> bucket : level) {
+          bucket.clear();
+        }
+      }
+      cursor = startTick;
+    }
+
+    long nextTick() {
+      long min = Long.MAX_VALUE;
+      for (List<ArrayDeque<ScheduledEvent<T>>> level : levels) {
+        for (ArrayDeque<ScheduledEvent<T>> bucket : level) {
+          if (!bucket.isEmpty()) {
+            for (ScheduledEvent<T> event : bucket) {
+              long tick = event.key().tick();
+              if (tick < min) {
+                min = tick;
+              }
+            }
+          }
+        }
+      }
+      return min;
+    }
+
+    void collectTick(long tick, Consumer<ScheduledEvent<T>> consumer) {
+      if (tick < cursor) {
+        throw new IllegalArgumentException(
+            "Cannot collect past tick " + tick + " when cursor=" + cursor);
+      }
+      cursor = tick;
+      for (int level = LEVEL_COUNT - 1; level >= 1; level--) {
+        int currentLevel = level;
+        drainLevel(currentLevel, tick, event -> enqueue(currentLevel - 1, event));
+      }
+      drainLevel(0, tick, consumer);
+    }
+
+    private void drainLevel(int level, long tick, Consumer<ScheduledEvent<T>> consumer) {
+      ArrayDeque<ScheduledEvent<T>> bucket = bucket(level, tick);
+      int initialSize = bucket.size();
+      for (int i = 0; i < initialSize; i++) {
+        ScheduledEvent<T> event = bucket.pollFirst();
+        if (event == null) {
+          break;
+        }
+        if (event.key().tick() == tick) {
+          consumer.accept(event);
+        } else {
+          bucket.addLast(event);
+        }
+      }
+    }
+
+    private void enqueue(int level, ScheduledEvent<T> event) {
+      bucket(level, event.key().tick()).addLast(event);
+    }
+
+    private ArrayDeque<ScheduledEvent<T>> bucket(int level, long tick) {
+      int slot = (int) ((tick >> (level * LEVEL_BITS)) & WHEEL_MASK);
+      return levels.get(level).get(slot);
+    }
+
+    private int selectLevel(long tick) {
+      long relative = tick - cursor;
+      int level = 0;
+      while (level < LEVEL_COUNT - 1) {
+        long span = 1L << ((level + 1) * LEVEL_BITS);
+        if (relative < span) {
+          break;
+        }
+        level++;
+      }
+      return level;
+    }
+  }
+}

--- a/engine/src/main/java/dev/fastquartz/engine/event/EventType.java
+++ b/engine/src/main/java/dev/fastquartz/engine/event/EventType.java
@@ -1,0 +1,23 @@
+package dev.fastquartz.engine.event;
+
+/** Locked event ordinals for deterministic scheduling. */
+public enum EventType {
+  SCHEDULED(0),
+  LOCAL_UPDATE(1),
+  POWER_PROP(2),
+  STATEFUL(3),
+  PISTON_TXN(4),
+  OBSERVER_EMIT(5),
+  XREG_OUT(6),
+  XREG_IN(7);
+
+  private final int eventOrdinal;
+
+  EventType(int eventOrdinal) {
+    this.eventOrdinal = eventOrdinal;
+  }
+
+  public int eventOrdinal() {
+    return eventOrdinal;
+  }
+}

--- a/engine/src/test/java/dev/fastquartz/engine/event/EventKeyTest.java
+++ b/engine/src/test/java/dev/fastquartz/engine/event/EventKeyTest.java
@@ -1,0 +1,47 @@
+package dev.fastquartz.engine.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EventKeyTest {
+  @Test
+  void packLocalOrderCombinesCoordinatesAndTypeOrdinal() {
+    long packed = EventKey.packLocalOrder(12, 34, 56, EventType.OBSERVER_EMIT);
+    long expected =
+        ((long) 34 << 40)
+            | ((long) 56 << 20)
+            | ((long) 12 << 4)
+            | EventType.OBSERVER_EMIT.eventOrdinal();
+    assertEquals(expected, packed);
+  }
+
+  @Test
+  void packLocalOrderRejectsOutOfRangeCoordinates() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> EventKey.packLocalOrder(-1, 0, 0, EventType.SCHEDULED));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> EventKey.packLocalOrder(0, 1 << 20, 0, EventType.SCHEDULED));
+  }
+
+  @Test
+  void compareToOrdersLexicographically() {
+    EventKey a = EventKey.forBlock(0, 0, 0, 1, 1, 1, EventType.SCHEDULED);
+    EventKey b = EventKey.forBlock(0, 1, 0, 1, 1, 1, EventType.SCHEDULED);
+    EventKey c = EventKey.forBlock(0, 1, 1, 1, 1, 1, EventType.SCHEDULED);
+    EventKey d = EventKey.forBlock(0, 1, 1, 1, 1, 2, EventType.LOCAL_UPDATE);
+    EventKey e = EventKey.forBlock(1, 0, 0, 1, 1, 1, EventType.SCHEDULED);
+
+    List<EventKey> keys = new ArrayList<>(List.of(e, d, c, b, a));
+    Collections.shuffle(keys);
+    Collections.sort(keys);
+
+    assertEquals(List.of(a, b, c, d, e), keys);
+  }
+}

--- a/engine/src/test/java/dev/fastquartz/engine/event/EventQueueTest.java
+++ b/engine/src/test/java/dev/fastquartz/engine/event/EventQueueTest.java
@@ -1,0 +1,109 @@
+package dev.fastquartz.engine.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EventQueueTest {
+  @Test
+  void eventsDequeueInLexicographicOrder() {
+    EventQueue<String> queue = new EventQueue<>();
+    List<EventKey> keys =
+        List.of(
+            EventKey.forBlock(1, 0, 0, 0, 0, 0, EventType.SCHEDULED),
+            EventKey.forBlock(1, 0, 0, 1, 0, 0, EventType.SCHEDULED),
+            EventKey.forBlock(4, 1, 0, 2, 0, 0, EventType.LOCAL_UPDATE),
+            EventKey.forBlock(8, 2, 1, 3, 1, 1, EventType.STATEFUL),
+            EventKey.forBlock(8, 3, 2, 3, 1, 1, EventType.STATEFUL));
+    List<EventKey> shuffled = new ArrayList<>(keys);
+    Collections.shuffle(shuffled);
+    for (int i = 0; i < shuffled.size(); i++) {
+      queue.schedule(shuffled.get(i), "event-" + i);
+    }
+
+    List<EventKey> drained = new ArrayList<>();
+    EventQueue.Event<String> event;
+    while ((event = queue.poll()) != null) {
+      drained.add(event.key());
+    }
+
+    assertEquals(keys, drained);
+  }
+
+  @Test
+  void identicalKeysPreserveInsertionOrder() {
+    EventQueue<String> queue = new EventQueue<>();
+    EventKey key = EventKey.forBlock(5, 4, 3, 2, 1, 0, EventType.POWER_PROP);
+    queue.schedule(key, "first");
+    queue.schedule(key, "second");
+
+    assertEquals("first", queue.poll().payload());
+    assertEquals("second", queue.poll().payload());
+    assertNull(queue.poll());
+  }
+
+  @Test
+  void timingWheelHandlesWideGaps() {
+    EventQueue<String> queue = new EventQueue<>();
+    long[] ticks = {3, 20, 300, 9_000, 120_000, 5_000_000, 120_000_000L};
+    for (long tick : ticks) {
+      queue.schedule(EventKey.forBlock(tick, 0, 0, 1, 0, 0, EventType.SCHEDULED), "tick-" + tick);
+    }
+
+    List<Long> drainedTicks = new ArrayList<>();
+    EventQueue.Event<String> event;
+    while ((event = queue.poll()) != null) {
+      drainedTicks.add(event.key().tick());
+    }
+
+    List<Long> expected = Arrays.stream(ticks).boxed().sorted().toList();
+    assertEquals(expected, drainedTicks);
+  }
+
+  @Test
+  void scheduleDuringActiveTickRunsWithinSameTick() {
+    EventQueue<String> queue = new EventQueue<>();
+    EventKey first = EventKey.forBlock(10, 0, 0, 0, 0, 0, EventType.SCHEDULED);
+    EventKey second = EventKey.forBlock(10, 5, 0, 1, 0, 0, EventType.LOCAL_UPDATE);
+
+    queue.schedule(first, "first");
+    EventQueue.Event<String> firstEvent = queue.poll();
+    assertEquals(first, firstEvent.key());
+
+    queue.schedule(second, "second");
+    EventQueue.Event<String> secondEvent = queue.poll();
+    assertEquals(second, secondEvent.key());
+    assertEquals(first.tick(), secondEvent.key().tick());
+  }
+
+  @Test
+  void schedulingEventsInThePastIsRejected() {
+    EventQueue<String> queue = new EventQueue<>();
+    EventKey baseline = EventKey.forBlock(4, 0, 0, 0, 0, 0, EventType.SCHEDULED);
+    queue.schedule(baseline, "baseline");
+    assertEquals(baseline, queue.poll().key());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> queue.schedule(EventKey.forBlock(3, 0, 0, 0, 0, 0, EventType.SCHEDULED), "late"));
+  }
+
+  @Test
+  void emptyQueueReportsAsEmpty() {
+    EventQueue<String> queue = new EventQueue<>();
+    assertTrue(queue.isEmpty());
+    queue.schedule(EventKey.forBlock(0, 0, 0, 0, 0, 0, EventType.SCHEDULED), "tick0");
+    assertFalse(queue.isEmpty());
+    queue.poll();
+    assertNull(queue.poll());
+    assertTrue(queue.isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary
- add an event type enum to lock micro-phase ordinals used by the scheduler
- implement an EventKey record plus a deterministic event queue backed by a hierarchical timing wheel
- cover the new ordering guarantees with unit tests for key packing, scheduling stability, and latency bounds

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68cc6d1c94cc8323ac2052d1a77ee9d8