### PR TITLE
Implement ShadowWorld overlay

### DIFF
--- a/engine/src/main/java/dev/fastquartz/engine/world/BlockPos.java
+++ b/engine/src/main/java/dev/fastquartz/engine/world/BlockPos.java
@@ -1,0 +1,8 @@
+package dev.fastquartz.engine.world;
+
+/** Simple immutable 3D integer coordinate. */
+public record BlockPos(int x, int y, int z) {
+  public static BlockPos of(int x, int y, int z) {
+    return new BlockPos(x, y, z);
+  }
+}

--- a/engine/src/main/java/dev/fastquartz/engine/world/ShadowWorld.java
+++ b/engine/src/main/java/dev/fastquartz/engine/world/ShadowWorld.java
@@ -1,0 +1,227 @@
+package dev.fastquartz.engine.world;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/**
+ * Shadow overlay for block mutations performed during a simulation tick.
+ *
+ * <p>The overlay buffers writes on a per chunk-section basis (16×16×16 blocks). Reads first consult
+ * the buffered changes; if a position has not been touched, data is sourced from the backing
+ * delegate. When {@link #commit()} is invoked all pending block state changes, scheduled ticks and
+ * neighbour notifications are applied to the delegate in a deterministic order.
+ */
+public final class ShadowWorld {
+  private static final int SECTION_SIZE = 16;
+  private static final int LOCAL_MASK = SECTION_SIZE - 1;
+
+  private static final Comparator<SectionPos> SECTION_ORDER =
+      Comparator.comparingInt(SectionPos::y)
+          .thenComparingInt(SectionPos::z)
+          .thenComparingInt(SectionPos::x);
+
+  private final Delegate delegate;
+  private final NavigableMap<SectionPos, SectionChanges> sectionChanges =
+      new TreeMap<>(SECTION_ORDER);
+  private final List<ScheduledTick> scheduledTicks = new ArrayList<>();
+  private final List<NeighborNotification> neighborNotifications = new ArrayList<>();
+
+  public ShadowWorld(Delegate delegate) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+  }
+
+  /** Returns the block state bits at the supplied position. */
+  public int getBlockStateBits(BlockPos pos) {
+    Objects.requireNonNull(pos, "pos");
+    SectionPos section = toSectionPos(pos);
+    SectionChanges changes = sectionChanges.get(section);
+    if (changes != null) {
+      int localIndex = toLocalIndex(pos);
+      int overlayIndex = changes.indexOf(localIndex);
+      if (overlayIndex >= 0) {
+        return changes.stateBitsAt(overlayIndex);
+      }
+    }
+    return delegate.getBlockStateBits(pos);
+  }
+
+  /** Buffers a block state update for the supplied position. */
+  public void setBlockStateBits(BlockPos pos, int stateBits) {
+    Objects.requireNonNull(pos, "pos");
+    SectionPos section = toSectionPos(pos);
+    int localIndex = toLocalIndex(pos);
+    SectionChanges changes = sectionChanges.get(section);
+    int overlayIndex = changes != null ? changes.indexOf(localIndex) : -1;
+    if (overlayIndex >= 0 && changes.stateBitsAt(overlayIndex) == stateBits) {
+      return; // already buffered with identical value
+    }
+
+    int baseState = delegate.getBlockStateBits(pos);
+    if (stateBits == baseState) {
+      if (changes != null && overlayIndex >= 0) {
+        changes.removeAt(overlayIndex);
+        if (changes.isEmpty()) {
+          sectionChanges.remove(section);
+        }
+      }
+      return;
+    }
+
+    if (changes == null) {
+      changes = new SectionChanges();
+      sectionChanges.put(section, changes);
+    }
+    changes.put(localIndex, stateBits);
+  }
+
+  /** Records a neighbour notification to be delivered at commit time. */
+  public void markNeighborChanged(BlockPos pos, BlockPos source) {
+    Objects.requireNonNull(pos, "pos");
+    Objects.requireNonNull(source, "source");
+    neighborNotifications.add(new NeighborNotification(pos, source));
+  }
+
+  /** Records a scheduled tick to be emitted during commit. */
+  public void scheduleTick(BlockPos pos, int delayTicks, int priority) {
+    Objects.requireNonNull(pos, "pos");
+    scheduledTicks.add(new ScheduledTick(pos, delayTicks, priority));
+  }
+
+  /** Applies all buffered mutations to the delegate in deterministic order. */
+  public void commit() {
+    for (Map.Entry<SectionPos, SectionChanges> entry : sectionChanges.entrySet()) {
+      SectionPos section = entry.getKey();
+      SectionChanges changes = entry.getValue();
+      for (int i = 0; i < changes.size(); i++) {
+        int localIndex = changes.localIndexAt(i);
+        int stateBits = changes.stateBitsAt(i);
+        BlockPos absolutePos = toBlockPos(section, localIndex);
+        delegate.setBlockStateBits(absolutePos, stateBits);
+      }
+    }
+    sectionChanges.clear();
+
+    if (!scheduledTicks.isEmpty()) {
+      for (ScheduledTick tick : scheduledTicks) {
+        delegate.scheduleTick(tick.pos(), tick.delayTicks(), tick.priority());
+      }
+      scheduledTicks.clear();
+    }
+
+    if (!neighborNotifications.isEmpty()) {
+      for (NeighborNotification notification : neighborNotifications) {
+        delegate.markNeighborChanged(notification.pos(), notification.source());
+      }
+      neighborNotifications.clear();
+    }
+  }
+
+  private static SectionPos toSectionPos(BlockPos pos) {
+    int sectionX = Math.floorDiv(pos.x(), SECTION_SIZE);
+    int sectionY = Math.floorDiv(pos.y(), SECTION_SIZE);
+    int sectionZ = Math.floorDiv(pos.z(), SECTION_SIZE);
+    return new SectionPos(sectionX, sectionY, sectionZ);
+  }
+
+  private static int toLocalIndex(BlockPos pos) {
+    int localX = Math.floorMod(pos.x(), SECTION_SIZE);
+    int localY = Math.floorMod(pos.y(), SECTION_SIZE);
+    int localZ = Math.floorMod(pos.z(), SECTION_SIZE);
+    return (localY << 8) | (localZ << 4) | localX;
+  }
+
+  private static BlockPos toBlockPos(SectionPos section, int localIndex) {
+    int localX = localIndex & LOCAL_MASK;
+    int localZ = (localIndex >> 4) & LOCAL_MASK;
+    int localY = (localIndex >> 8) & LOCAL_MASK;
+    int worldX = (section.x() << 4) + localX;
+    int worldY = (section.y() << 4) + localY;
+    int worldZ = (section.z() << 4) + localZ;
+    return new BlockPos(worldX, worldY, worldZ);
+  }
+
+  private record SectionPos(int x, int y, int z) {}
+
+  private static final class SectionChanges {
+    private int[] localIndices = new int[4];
+    private int[] stateBits = new int[4];
+    private int size;
+
+    int size() {
+      return size;
+    }
+
+    int localIndexAt(int index) {
+      return localIndices[index];
+    }
+
+    int stateBitsAt(int index) {
+      return stateBits[index];
+    }
+
+    int indexOf(int localIndex) {
+      return java.util.Arrays.binarySearch(localIndices, 0, size, localIndex);
+    }
+
+    void put(int localIndex, int value) {
+      int idx = indexOf(localIndex);
+      if (idx >= 0) {
+        stateBits[idx] = value;
+        return;
+      }
+      ensureCapacity(size + 1);
+      int insertIdx = -(idx + 1);
+      System.arraycopy(localIndices, insertIdx, localIndices, insertIdx + 1, size - insertIdx);
+      System.arraycopy(stateBits, insertIdx, stateBits, insertIdx + 1, size - insertIdx);
+      localIndices[insertIdx] = localIndex;
+      stateBits[insertIdx] = value;
+      size++;
+    }
+
+    boolean removeAt(int index) {
+      if (index < 0 || index >= size) {
+        return false;
+      }
+      int elementsToMove = size - index - 1;
+      if (elementsToMove > 0) {
+        System.arraycopy(localIndices, index + 1, localIndices, index, elementsToMove);
+        System.arraycopy(stateBits, index + 1, stateBits, index, elementsToMove);
+      }
+      size--;
+      return true;
+    }
+
+    boolean isEmpty() {
+      return size == 0;
+    }
+
+    private void ensureCapacity(int desiredCapacity) {
+      if (desiredCapacity <= localIndices.length) {
+        return;
+      }
+      int newCapacity = Math.max(desiredCapacity, localIndices.length * 2);
+      localIndices = java.util.Arrays.copyOf(localIndices, newCapacity);
+      stateBits = java.util.Arrays.copyOf(stateBits, newCapacity);
+    }
+  }
+
+  private record ScheduledTick(BlockPos pos, int delayTicks, int priority) {}
+
+  private record NeighborNotification(BlockPos pos, BlockPos source) {}
+
+  /** Backing world interface used by the overlay. */
+  public interface Delegate {
+    int getBlockStateBits(BlockPos pos);
+
+    void setBlockStateBits(BlockPos pos, int stateBits);
+
+    void scheduleTick(BlockPos pos, int delayTicks, int priority);
+
+    void markNeighborChanged(BlockPos pos, BlockPos source);
+  }
+}

--- a/engine/src/test/java/dev/fastquartz/engine/world/ShadowWorldTest.java
+++ b/engine/src/test/java/dev/fastquartz/engine/world/ShadowWorldTest.java
@@ -1,0 +1,175 @@
+package dev.fastquartz.engine.world;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ShadowWorldTest {
+  @Test
+  void passthroughWhenUntouched() {
+    RecordingWorld world = new RecordingWorld();
+    BlockPos pos = BlockPos.of(1, 2, 3);
+    world.prime(pos, 42);
+    ShadowWorld overlay = new ShadowWorld(world);
+
+    assertEquals(42, overlay.getBlockStateBits(pos));
+  }
+
+  @Test
+  void setBlockStateBuffersUntilCommit() {
+    RecordingWorld world = new RecordingWorld();
+    BlockPos pos = BlockPos.of(4, 5, 6);
+    world.prime(pos, 7);
+    ShadowWorld overlay = new ShadowWorld(world);
+
+    overlay.setBlockStateBits(pos, 9);
+    assertEquals(9, overlay.getBlockStateBits(pos));
+    assertTrue(world.writes.isEmpty());
+
+    overlay.commit();
+
+    assertEquals(9, world.getBlockStateBits(pos));
+    assertEquals(List.of(new BlockWrite(pos, 9)), world.writes);
+    assertEquals(9, overlay.getBlockStateBits(pos));
+  }
+
+  @Test
+  void settingStateBackToBaseRemovesBufferedChange() {
+    RecordingWorld world = new RecordingWorld();
+    BlockPos pos = BlockPos.of(7, 8, 9);
+    world.prime(pos, 15);
+    ShadowWorld overlay = new ShadowWorld(world);
+
+    overlay.setBlockStateBits(pos, 1);
+    assertEquals(1, overlay.getBlockStateBits(pos));
+
+    overlay.setBlockStateBits(pos, 15); // back to base value
+    assertEquals(15, overlay.getBlockStateBits(pos));
+
+    overlay.commit();
+    assertTrue(world.writes.isEmpty());
+  }
+
+  @Test
+  void commitAppliesWritesInDeterministicOrder() {
+    RecordingWorld world = new RecordingWorld();
+    ShadowWorld overlay = new ShadowWorld(world);
+
+    BlockPos a = BlockPos.of(-1, -1, 0);
+    BlockPos b = BlockPos.of(0, 0, 0);
+    BlockPos c = BlockPos.of(1, 0, 0);
+    BlockPos d = BlockPos.of(0, 0, 1);
+    BlockPos e = BlockPos.of(5, 17, 5);
+    BlockPos f = BlockPos.of(5, 32, 5);
+
+    overlay.setBlockStateBits(b, 2);
+    overlay.setBlockStateBits(f, 3);
+    overlay.setBlockStateBits(d, 4);
+    overlay.setBlockStateBits(a, 5);
+    overlay.setBlockStateBits(e, 6);
+    overlay.setBlockStateBits(c, 7);
+
+    overlay.commit();
+
+    assertEquals(
+        List.of(
+            new BlockWrite(a, 5),
+            new BlockWrite(b, 2),
+            new BlockWrite(c, 7),
+            new BlockWrite(d, 4),
+            new BlockWrite(e, 6),
+            new BlockWrite(f, 3)),
+        world.writes);
+  }
+
+  @Test
+  void neighbourNotificationsFlushOnCommit() {
+    RecordingWorld world = new RecordingWorld();
+    ShadowWorld overlay = new ShadowWorld(world);
+    BlockPos pos = BlockPos.of(2, 2, 2);
+    BlockPos source = BlockPos.of(3, 3, 3);
+
+    overlay.markNeighborChanged(pos, source);
+    assertTrue(world.neighbourNotifications.isEmpty());
+
+    overlay.commit();
+    assertEquals(List.of(new NeighborCall(pos, source)), world.neighbourNotifications);
+
+    int notifications = world.neighbourNotifications.size();
+    overlay.commit();
+    assertEquals(notifications, world.neighbourNotifications.size());
+  }
+
+  @Test
+  void scheduledTicksFlushOnCommit() {
+    RecordingWorld world = new RecordingWorld();
+    ShadowWorld overlay = new ShadowWorld(world);
+    BlockPos pos = BlockPos.of(9, 9, 9);
+
+    overlay.scheduleTick(pos, 4, 1);
+    assertTrue(world.scheduledTicks.isEmpty());
+
+    overlay.commit();
+    assertEquals(List.of(new ScheduledTickCall(pos, 4, 1)), world.scheduledTicks);
+
+    int scheduled = world.scheduledTicks.size();
+    overlay.commit();
+    assertEquals(scheduled, world.scheduledTicks.size());
+  }
+
+  @Test
+  void secondCommitWithNoChangesDoesNothing() {
+    RecordingWorld world = new RecordingWorld();
+    ShadowWorld overlay = new ShadowWorld(world);
+    BlockPos pos = BlockPos.of(1, 1, 1);
+
+    overlay.setBlockStateBits(pos, 12);
+    overlay.commit();
+    int writesAfterFirst = world.writes.size();
+    overlay.commit();
+    assertEquals(writesAfterFirst, world.writes.size());
+  }
+
+  private static final class RecordingWorld implements ShadowWorld.Delegate {
+    private final Map<BlockPos, Integer> states = new HashMap<>();
+    private final List<BlockWrite> writes = new ArrayList<>();
+    private final List<NeighborCall> neighbourNotifications = new ArrayList<>();
+    private final List<ScheduledTickCall> scheduledTicks = new ArrayList<>();
+
+    @Override
+    public int getBlockStateBits(BlockPos pos) {
+      return states.getOrDefault(pos, 0);
+    }
+
+    @Override
+    public void setBlockStateBits(BlockPos pos, int stateBits) {
+      states.put(pos, stateBits);
+      writes.add(new BlockWrite(pos, stateBits));
+    }
+
+    @Override
+    public void scheduleTick(BlockPos pos, int delayTicks, int priority) {
+      scheduledTicks.add(new ScheduledTickCall(pos, delayTicks, priority));
+    }
+
+    @Override
+    public void markNeighborChanged(BlockPos pos, BlockPos source) {
+      neighbourNotifications.add(new NeighborCall(pos, source));
+    }
+
+    void prime(BlockPos pos, int stateBits) {
+      states.put(pos, stateBits);
+    }
+  }
+
+  private record BlockWrite(BlockPos pos, int stateBits) {}
+
+  private record NeighborCall(BlockPos pos, BlockPos source) {}
+
+  private record ScheduledTickCall(BlockPos pos, int delayTicks, int priority) {}
+}


### PR DESCRIPTION
## Summary
- add a simple `BlockPos` record for engine-side world coordinate bookkeeping
- implement the ShadowWorld overlay with per-section buffering and deterministic commit/flush behaviour
- add unit tests that exercise reads, writes, neighbour notifications, scheduled ticks, and idempotent commits

## Testing
- ./gradlew :engine:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cc8d47808c8323a524b56aa932cbf9