### PR TITLE
Implement scheduled tick routing and server hooks

### DIFF
--- a/engine/src/main/java/dev/fastquartz/engine/event/EventQueue.java
+++ b/engine/src/main/java/dev/fastquartz/engine/event/EventQueue.java
@@ -70,6 +70,21 @@ public final class EventQueue<T> {
     return scheduled.toEvent();
   }
 
+  /**
+   * Returns, but does not remove, the next event in deterministic order. The caller may
+   * subsequently invoke {@link #poll()} to consume the same event.
+   */
+  public Event<T> peek() {
+    if (!ensureReady()) {
+      return null;
+    }
+    ScheduledEvent<T> scheduled = readyQueue.peek();
+    if (scheduled == null) {
+      return null;
+    }
+    return scheduled.toEvent();
+  }
+
   private boolean ensureReady() {
     if (!readyQueue.isEmpty()) {
       return true;

--- a/engine/src/main/java/dev/fastquartz/engine/world/ShadowWorld.java
+++ b/engine/src/main/java/dev/fastquartz/engine/world/ShadowWorld.java
@@ -145,7 +145,9 @@ public final class ShadowWorld {
     return new BlockPos(worldX, worldY, worldZ);
   }
 
-  private record SectionPos(int x, int y, int z) {}
+  private record SectionPos(int x, int y, int z) {
+    // Marker record for section keys.
+  }
 
   private static final class SectionChanges {
     private int[] localIndices = new int[4];
@@ -210,9 +212,13 @@ public final class ShadowWorld {
     }
   }
 
-  private record ScheduledTick(BlockPos pos, int delayTicks, int priority) {}
+  private record ScheduledTick(BlockPos pos, int delayTicks, int priority) {
+    // Record used to stage scheduled ticks during commit.
+  }
 
-  private record NeighborNotification(BlockPos pos, BlockPos source) {}
+  private record NeighborNotification(BlockPos pos, BlockPos source) {
+    // Record used to flush neighbour updates.
+  }
 
   /** Backing world interface used by the overlay. */
   public interface Delegate {

--- a/engine/src/test/java/dev/fastquartz/engine/event/EventQueueTest.java
+++ b/engine/src/test/java/dev/fastquartz/engine/event/EventQueueTest.java
@@ -106,4 +106,20 @@ class EventQueueTest {
     assertNull(queue.poll());
     assertTrue(queue.isEmpty());
   }
+
+  @Test
+  void peekReturnsNextEventWithoutRemoval() {
+    EventQueue<String> queue = new EventQueue<>();
+    EventKey key = EventKey.forBlock(2, 0, 0, 0, 0, 0, EventType.SCHEDULED);
+    queue.schedule(key, "payload");
+
+    EventQueue.Event<String> peeked = queue.peek();
+    assertEquals(key, peeked.key());
+    assertEquals("payload", peeked.payload());
+
+    EventQueue.Event<String> polled = queue.poll();
+    assertEquals(key, polled.key());
+    assertEquals("payload", polled.payload());
+    assertNull(queue.poll());
+  }
 }

--- a/engine/src/test/java/dev/fastquartz/engine/world/ShadowWorldTest.java
+++ b/engine/src/test/java/dev/fastquartz/engine/world/ShadowWorldTest.java
@@ -167,9 +167,15 @@ class ShadowWorldTest {
     }
   }
 
-  private record BlockWrite(BlockPos pos, int stateBits) {}
+  private record BlockWrite(BlockPos pos, int stateBits) {
+    // Recording helper for block writes.
+  }
 
-  private record NeighborCall(BlockPos pos, BlockPos source) {}
+  private record NeighborCall(BlockPos pos, BlockPos source) {
+    // Recording helper for neighbour notifications.
+  }
 
-  private record ScheduledTickCall(BlockPos pos, int delayTicks, int priority) {}
+  private record ScheduledTickCall(BlockPos pos, int delayTicks, int priority) {
+    // Recording helper for scheduled ticks.
+  }
 }

--- a/mod/src/main/java/dev/fastquartz/mod/server/RedstoneTickRouter.java
+++ b/mod/src/main/java/dev/fastquartz/mod/server/RedstoneTickRouter.java
@@ -1,0 +1,104 @@
+package dev.fastquartz.mod.server;
+
+import dev.fastquartz.engine.FastQuartzEngine;
+import dev.fastquartz.engine.event.EventKey;
+import dev.fastquartz.engine.event.EventQueue;
+import dev.fastquartz.engine.event.EventType;
+import java.util.Objects;
+import net.minecraft.server.world.ServerTickScheduler;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ticks.TickPriority;
+
+/** Routes scheduled ticks from the stubbed server world into the Fast Quartz event queue. */
+public final class RedstoneTickRouter {
+  private static final int REGION_BLOCK_SIZE = 64; // 4×4 chunks.
+
+  private final FastQuartzEngine engine;
+  private final EventQueue<ScheduledTick> queue = new EventQueue<>();
+  private long activeTick = Long.MIN_VALUE;
+  private boolean draining;
+
+  public RedstoneTickRouter(FastQuartzEngine engine) {
+    this.engine = Objects.requireNonNull(engine, "engine");
+  }
+
+  public FastQuartzEngine engine() {
+    return engine;
+  }
+
+  public void clear() {
+    queue.clear();
+    activeTick = Long.MIN_VALUE;
+    draining = false;
+  }
+
+  public void schedule(
+      ServerWorld world,
+      BlockPos pos,
+      int delayTicks,
+      TickPriority priority,
+      ServerTickScheduler.ScheduledTickReceiver receiver) {
+    Objects.requireNonNull(world, "world");
+    Objects.requireNonNull(pos, "pos");
+    Objects.requireNonNull(priority, "priority");
+    Objects.requireNonNull(receiver, "receiver");
+
+    long baseline = world.currentTick();
+    if (draining && activeTick > baseline) {
+      baseline = activeTick;
+    }
+
+    long dueTick = baseline + Math.max(delayTicks, 0);
+    EventKey key =
+        EventKey.forBlock(
+            dueTick,
+            microPhase(priority),
+            regionId(pos),
+            localX(pos),
+            pos.getY(),
+            localZ(pos),
+            EventType.SCHEDULED);
+    queue.schedule(key, new ScheduledTick(world, pos, receiver));
+  }
+
+  public void runDueTicks(ServerWorld world) {
+    Objects.requireNonNull(world, "world");
+    activeTick = world.currentTick();
+    EventQueue.Event<ScheduledTick> next;
+    while ((next = queue.peek()) != null && next.key().tick() <= activeTick) {
+      queue.poll();
+      draining = true;
+      try {
+        next.payload().run();
+      } finally {
+        draining = false;
+      }
+    }
+  }
+
+  private static int microPhase(TickPriority priority) {
+    return Math.max(0, Math.min(9, priority.value()));
+  }
+
+  private static int regionId(BlockPos pos) {
+    int regionX = Math.floorDiv(pos.getX(), REGION_BLOCK_SIZE);
+    int regionZ = Math.floorDiv(pos.getZ(), REGION_BLOCK_SIZE);
+    return ((regionX & 0xFFFF) << 16) | (regionZ & 0xFFFF);
+  }
+
+  private static int localX(BlockPos pos) {
+    return Math.floorMod(pos.getX(), REGION_BLOCK_SIZE);
+  }
+
+  private static int localZ(BlockPos pos) {
+    return Math.floorMod(pos.getZ(), REGION_BLOCK_SIZE);
+  }
+
+  private record ScheduledTick(
+      ServerWorld world, BlockPos pos, ServerTickScheduler.ScheduledTickReceiver receiver) {
+    void run() {
+      receiver.run(world, pos);
+    }
+  }
+}

--- a/mod/src/main/java/net/minecraft/server/world/ServerTickScheduler.java
+++ b/mod/src/main/java/net/minecraft/server/world/ServerTickScheduler.java
@@ -1,0 +1,30 @@
+package net.minecraft.server.world;
+
+import dev.fastquartz.mod.server.RedstoneTickRouter;
+import java.util.Objects;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ticks.TickPriority;
+
+/** Minimal hook surface for {@code ServerTickScheduler}. */
+public final class ServerTickScheduler {
+  private final ServerWorld world;
+  private final RedstoneTickRouter router;
+
+  ServerTickScheduler(ServerWorld world, RedstoneTickRouter router) {
+    this.world = Objects.requireNonNull(world, "world");
+    this.router = Objects.requireNonNull(router, "router");
+  }
+
+  public void scheduleTick(
+      BlockPos pos, ScheduledTickReceiver receiver, int delay, TickPriority priority) {
+    router.schedule(world, pos, delay, priority, receiver);
+  }
+
+  public void scheduleTick(BlockPos pos, ScheduledTickReceiver receiver, int delay) {
+    scheduleTick(pos, receiver, delay, TickPriority.NORMAL);
+  }
+
+  public interface ScheduledTickReceiver {
+    void run(ServerWorld world, BlockPos pos);
+  }
+}

--- a/mod/src/main/java/net/minecraft/server/world/ServerWorld.java
+++ b/mod/src/main/java/net/minecraft/server/world/ServerWorld.java
@@ -1,0 +1,43 @@
+package net.minecraft.server.world;
+
+import dev.fastquartz.engine.FastQuartzEngine;
+import dev.fastquartz.mod.server.RedstoneTickRouter;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+
+/** Minimal stub of Minecraft's {@code ServerWorld} focused on scheduled tick redirection. */
+public final class ServerWorld {
+  private final FastQuartzEngine engine;
+  private final RedstoneTickRouter redstoneRouter;
+  private final ServerTickScheduler blockTickScheduler;
+  private long currentTick;
+
+  public ServerWorld(FastQuartzEngine engine) {
+    this.engine = Objects.requireNonNull(engine, "engine");
+    this.redstoneRouter = new RedstoneTickRouter(engine);
+    this.blockTickScheduler = new ServerTickScheduler(this, redstoneRouter);
+  }
+
+  /** Runs one world tick and drains scheduled redstone work from the router. */
+  public void tick(BooleanSupplier shouldKeepTicking) {
+    Objects.requireNonNull(shouldKeepTicking, "shouldKeepTicking");
+    currentTick++;
+    redstoneRouter.runDueTicks(this);
+  }
+
+  public long currentTick() {
+    return currentTick;
+  }
+
+  public FastQuartzEngine engine() {
+    return engine;
+  }
+
+  public ServerTickScheduler blockTickScheduler() {
+    return blockTickScheduler;
+  }
+
+  public RedstoneTickRouter redstoneRouter() {
+    return redstoneRouter;
+  }
+}

--- a/mod/src/main/java/net/minecraft/util/math/BlockPos.java
+++ b/mod/src/main/java/net/minecraft/util/math/BlockPos.java
@@ -1,0 +1,24 @@
+package net.minecraft.util.math;
+
+/** Minimal stub of Minecraft's {@code BlockPos}. */
+public record BlockPos(int x, int y, int z) {
+  public BlockPos {
+    // Vanilla worlds clamp Y to a finite range; the stub simply records the coordinates.
+  }
+
+  public static BlockPos of(int x, int y, int z) {
+    return new BlockPos(x, y, z);
+  }
+
+  public int getX() {
+    return x;
+  }
+
+  public int getY() {
+    return y;
+  }
+
+  public int getZ() {
+    return z;
+  }
+}

--- a/mod/src/main/java/net/minecraft/world/ticks/TickPriority.java
+++ b/mod/src/main/java/net/minecraft/world/ticks/TickPriority.java
@@ -1,0 +1,23 @@
+package net.minecraft.world.ticks;
+
+/** Minimal subset of Minecraft's {@code TickPriority}. */
+public enum TickPriority {
+  EXTREMELY_LOW(6),
+  VERY_LOW(5),
+  LOW(4),
+  NORMAL(3),
+  HIGH(2),
+  VERY_HIGH(1),
+  EXTREMELY_HIGH(0);
+
+  private final int value;
+
+  TickPriority(int value) {
+    this.value = value;
+  }
+
+  /** Lower values run earlier within the same tick. */
+  public int value() {
+    return value;
+  }
+}

--- a/mod/src/test/java/dev/fastquartz/mod/server/RedstoneTickRouterTest.java
+++ b/mod/src/test/java/dev/fastquartz/mod/server/RedstoneTickRouterTest.java
@@ -1,0 +1,115 @@
+package dev.fastquartz.mod.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import dev.fastquartz.engine.FastQuartzEngine;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.minecraft.server.world.ServerTickScheduler;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ticks.TickPriority;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RedstoneTickRouterTest {
+  private ServerWorld world;
+  private ServerTickScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    world = new ServerWorld(FastQuartzEngine.create(20));
+    scheduler = world.blockTickScheduler();
+  }
+
+  @Test
+  void scheduledTickRunsAfterRequestedDelay() {
+    List<Long> executedTicks = new ArrayList<>();
+    ServerTickScheduler.ScheduledTickReceiver receiver =
+        (serverWorld, pos) -> executedTicks.add(serverWorld.currentTick());
+
+    scheduler.scheduleTick(BlockPos.of(0, 64, 0), receiver, 2, TickPriority.NORMAL);
+
+    tickWorld(1);
+    assertEquals(List.of(), executedTicks);
+
+    tickWorld(1);
+    assertEquals(List.of(2L), executedTicks);
+  }
+
+  @Test
+  void schedulingDuringTickRunsInSameTickAfterCurrentTask() {
+    List<String> events = new ArrayList<>();
+    ServerTickScheduler.ScheduledTickReceiver secondary =
+        (serverWorld, pos) -> events.add("secondary@" + serverWorld.currentTick());
+
+    ServerTickScheduler.ScheduledTickReceiver primary =
+        new ServerTickScheduler.ScheduledTickReceiver() {
+          private boolean scheduled;
+
+          @Override
+          public void run(ServerWorld serverWorld, BlockPos pos) {
+            events.add("primary@" + serverWorld.currentTick());
+            if (!scheduled) {
+              scheduled = true;
+              scheduler.scheduleTick(pos, secondary, 0, TickPriority.NORMAL);
+            }
+          }
+        };
+
+    scheduler.scheduleTick(BlockPos.of(1, 70, 1), primary, 0, TickPriority.NORMAL);
+    tickWorld(1);
+
+    assertEquals(List.of("primary@1", "secondary@1"), events);
+  }
+
+  @Test
+  void higherPriorityTicksExecuteFirstWithinSameTick() {
+    List<String> events = new ArrayList<>();
+    BlockPos pos = BlockPos.of(2, 64, 2);
+
+    scheduler.scheduleTick(pos, (world, p) -> events.add("low"), 1, TickPriority.LOW);
+    scheduler.scheduleTick(pos, (world, p) -> events.add("high"), 1, TickPriority.HIGH);
+
+    tickWorld(1);
+
+    assertEquals(List.of("high", "low"), events);
+  }
+
+  @Test
+  void neighborPathDoesNotRecurseIntoVanillaCallStack() {
+    List<String> events = new ArrayList<>();
+    AtomicBoolean primaryRunning = new AtomicBoolean();
+
+    ServerTickScheduler.ScheduledTickReceiver secondary =
+        (serverWorld, pos) -> {
+          events.add("secondary@" + serverWorld.currentTick());
+          assertFalse(primaryRunning.get(), "secondary executed during primary recursion");
+        };
+
+    ServerTickScheduler.ScheduledTickReceiver primary =
+        (serverWorld, pos) -> {
+          primaryRunning.set(true);
+          events.add("primary@" + serverWorld.currentTick());
+          try {
+            BlockPos neighbor = BlockPos.of(pos.getX() + 1, pos.getY(), pos.getZ());
+            scheduler.scheduleTick(neighbor, secondary, 0, TickPriority.HIGH);
+          } finally {
+            primaryRunning.set(false);
+          }
+        };
+
+    scheduler.scheduleTick(BlockPos.of(3, 64, 3), primary, 0, TickPriority.NORMAL);
+    tickWorld(1);
+
+    assertEquals(List.of("primary@1", "secondary@1"), events);
+  }
+
+  private void tickWorld(int ticks) {
+    for (int i = 0; i < ticks; i++) {
+      world.tick(() -> true);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a RedstoneTickRouter that forwards server scheduled ticks through the Fast Quartz event queue
- stub ServerWorld/ServerTickScheduler/BlockPos/TickPriority to model the mixin hook points
- expose EventQueue.peek and cover the redirect path with new unit tests

## Testing
- ./gradlew check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cc911d5c3c8323a8a790be96cf99e8