### PR TITLE
Implement dust CSR compression builder

### DIFF
--- a/engine/src/main/java/dev/fastquartz/engine/dust/DustCsrBuilder.java
+++ b/engine/src/main/java/dev/fastquartz/engine/dust/DustCsrBuilder.java
@@ -1,0 +1,297 @@
+package dev.fastquartz.engine.dust;
+
+import dev.fastquartz.engine.world.BlockPos;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/** Builds the compressed dust CSR graph from a world snapshot. */
+public final class DustCsrBuilder {
+  private static final int[][] NEIGHBOR_OFFSETS = {
+    {0, 1, 0}, // up
+    {0, -1, 0}, // down
+    {0, 0, 1}, // south (positive Z)
+    {0, 0, -1}, // north (negative Z)
+    {1, 0, 0}, // east (positive X)
+    {-1, 0, 0}, // west (negative X)
+  };
+
+  private static final Comparator<BlockPos> POSITION_ORDER =
+      Comparator.comparingInt(BlockPos::y)
+          .thenComparingInt(BlockPos::z)
+          .thenComparingInt(BlockPos::x);
+
+  private final Set<BlockPos> dustPositions = new HashSet<>();
+  private final Map<BlockPos, List<DustPort>> attachmentsByPosition = new HashMap<>();
+  private final Map<DustPort, BlockPos> portBindings = new HashMap<>();
+
+  /** Adds a dust block to the builder. */
+  public DustCsrBuilder addDust(BlockPos pos) {
+    Objects.requireNonNull(pos, "pos");
+    dustPositions.add(pos);
+    return this;
+  }
+
+  /** Adds all supplied dust blocks to the builder. */
+  public DustCsrBuilder addAllDust(Collection<BlockPos> positions) {
+    Objects.requireNonNull(positions, "positions");
+    for (BlockPos pos : positions) {
+      addDust(pos);
+    }
+    return this;
+  }
+
+  /** Attaches a component port to the provided dust block. */
+  public DustCsrBuilder attachPort(DustPort port, BlockPos dustPos) {
+    Objects.requireNonNull(port, "port");
+    Objects.requireNonNull(dustPos, "dustPos");
+    BlockPos existing = portBindings.putIfAbsent(port, dustPos);
+    if (existing != null && !existing.equals(dustPos)) {
+      throw new IllegalArgumentException("Port " + port + " already attached to " + existing);
+    }
+    List<DustPort> ports = attachmentsByPosition.computeIfAbsent(dustPos, key -> new ArrayList<>());
+    if (!ports.contains(port)) {
+      ports.add(port);
+    }
+    return this;
+  }
+
+  /** Builds the compressed dust graph. */
+  public DustCsrGraph build() {
+    if (dustPositions.isEmpty()) {
+      return DustCsrGraph.empty();
+    }
+
+    validateAttachmentPositions();
+
+    Map<BlockPos, List<BlockPos>> adjacency = buildAdjacency();
+    List<List<BlockPos>> islands = discoverIslands(adjacency);
+
+    List<BlockPos> nodePositions = new ArrayList<>();
+    List<Integer> nodeIslandIds = new ArrayList<>();
+    Map<BlockPos, Integer> positionToNode = new HashMap<>();
+
+    for (int islandId = 0; islandId < islands.size(); islandId++) {
+      List<BlockPos> islandPositions = islands.get(islandId);
+      Set<BlockPos> nodes = identifyNodes(islandPositions, adjacency);
+      List<BlockPos> sortedNodes = new ArrayList<>(nodes);
+      sortedNodes.sort(POSITION_ORDER);
+      for (BlockPos pos : sortedNodes) {
+        int nodeId = nodePositions.size();
+        nodePositions.add(pos);
+        nodeIslandIds.add(islandId);
+        positionToNode.put(pos, nodeId);
+      }
+    }
+
+    int nodeCount = nodePositions.size();
+    if (nodeCount == 0) {
+      // Degenerate case: dust exists but all nodes collapsed. Create a single node to represent it.
+      BlockPos fallback = dustPositions.stream().min(POSITION_ORDER).orElseThrow();
+      nodePositions.add(fallback);
+      nodeIslandIds.add(0);
+      positionToNode.put(fallback, 0);
+      nodeCount = 1;
+    }
+
+    int[] edgeIndex = new int[nodeCount + 1];
+    List<Integer> edgeTargetsList = new ArrayList<>();
+    List<Integer> edgeWeightsList = new ArrayList<>();
+
+    int maxSteps = dustPositions.size();
+
+    for (int nodeId = 0; nodeId < nodeCount; nodeId++) {
+      BlockPos nodePos = nodePositions.get(nodeId);
+      List<BlockPos> neighbours = adjacency.getOrDefault(nodePos, List.of());
+      edgeIndex[nodeId] = edgeTargetsList.size();
+      List<EdgeCandidate> candidates = new ArrayList<>();
+      for (BlockPos neighbour : neighbours) {
+        Traversal traversal = walk(nodePos, neighbour, adjacency, positionToNode, maxSteps);
+        if (traversal == null) {
+          continue;
+        }
+        Integer targetNode = positionToNode.get(traversal.target());
+        if (targetNode == null || targetNode == nodeId) {
+          continue;
+        }
+        candidates.add(new EdgeCandidate(targetNode, traversal.weight()));
+      }
+      candidates.sort(EdgeCandidate.ORDER);
+      for (EdgeCandidate candidate : candidates) {
+        edgeTargetsList.add(candidate.targetNode());
+        edgeWeightsList.add(candidate.weight());
+      }
+    }
+    edgeIndex[nodeCount] = edgeTargetsList.size();
+
+    int[] islandIds = nodeIslandIds.stream().mapToInt(Integer::intValue).toArray();
+    int[] edgeTargets = edgeTargetsList.stream().mapToInt(Integer::intValue).toArray();
+    int[] edgeWeights = edgeWeightsList.stream().mapToInt(Integer::intValue).toArray();
+
+    Map<DustPort, Integer> portToNode = buildPortMapping(positionToNode);
+
+    return new DustCsrGraph(nodePositions, islandIds, edgeIndex, edgeTargets, edgeWeights, portToNode, positionToNode);
+  }
+
+  private void validateAttachmentPositions() {
+    for (Map.Entry<DustPort, BlockPos> entry : portBindings.entrySet()) {
+      if (!dustPositions.contains(entry.getValue())) {
+        throw new IllegalStateException(
+            "Port " + entry.getKey() + " attached to non-dust position " + entry.getValue());
+      }
+    }
+  }
+
+  private Map<BlockPos, List<BlockPos>> buildAdjacency() {
+    Map<BlockPos, List<BlockPos>> adjacency = new HashMap<>();
+    for (BlockPos pos : dustPositions) {
+      List<BlockPos> neighbours = new ArrayList<>();
+      for (int[] offset : NEIGHBOR_OFFSETS) {
+        BlockPos neighbour =
+            BlockPos.of(pos.x() + offset[0], pos.y() + offset[1], pos.z() + offset[2]);
+        if (dustPositions.contains(neighbour)) {
+          neighbours.add(neighbour);
+        }
+      }
+      neighbours.sort(POSITION_ORDER);
+      adjacency.put(pos, neighbours);
+    }
+    return adjacency;
+  }
+
+  private List<List<BlockPos>> discoverIslands(Map<BlockPos, List<BlockPos>> adjacency) {
+    List<BlockPos> sorted = new ArrayList<>(dustPositions);
+    sorted.sort(POSITION_ORDER);
+    Set<BlockPos> visited = new HashSet<>();
+    List<List<BlockPos>> islands = new ArrayList<>();
+
+    for (BlockPos start : sorted) {
+      if (!visited.add(start)) {
+        continue;
+      }
+      List<BlockPos> island = new ArrayList<>();
+      Deque<BlockPos> queue = new ArrayDeque<>();
+      queue.add(start);
+      while (!queue.isEmpty()) {
+        BlockPos current = queue.removeFirst();
+        island.add(current);
+        for (BlockPos neighbour : adjacency.getOrDefault(current, List.of())) {
+          if (visited.add(neighbour)) {
+            queue.addLast(neighbour);
+          }
+        }
+      }
+      island.sort(POSITION_ORDER);
+      islands.add(island);
+    }
+
+    return islands;
+  }
+
+  private Set<BlockPos> identifyNodes(
+      List<BlockPos> islandPositions, Map<BlockPos, List<BlockPos>> adjacency) {
+    Set<BlockPos> nodes = new HashSet<>();
+    for (BlockPos pos : islandPositions) {
+      List<BlockPos> neighbours = adjacency.getOrDefault(pos, List.of());
+      int degree = neighbours.size();
+      boolean hasAttachment = attachmentsByPosition.containsKey(pos);
+      boolean isCorner = false;
+      if (degree == 2) {
+        BlockPos first = neighbours.get(0);
+        BlockPos second = neighbours.get(1);
+        int dx1 = first.x() - pos.x();
+        int dy1 = first.y() - pos.y();
+        int dz1 = first.z() - pos.z();
+        int dx2 = second.x() - pos.x();
+        int dy2 = second.y() - pos.y();
+        int dz2 = second.z() - pos.z();
+        boolean opposite = dx1 == -dx2 && dy1 == -dy2 && dz1 == -dz2;
+        isCorner = !opposite;
+      }
+      if (degree != 2 || hasAttachment || isCorner) {
+        nodes.add(pos);
+      }
+    }
+
+    if (nodes.isEmpty() && !islandPositions.isEmpty()) {
+      BlockPos first = islandPositions.get(0);
+      nodes.add(first);
+      List<BlockPos> neighbours = adjacency.getOrDefault(first, List.of());
+      if (!neighbours.isEmpty()) {
+        nodes.add(neighbours.get(0));
+      }
+    }
+
+    return nodes;
+  }
+
+  private Traversal walk(
+      BlockPos start,
+      BlockPos next,
+      Map<BlockPos, List<BlockPos>> adjacency,
+      Map<BlockPos, Integer> positionToNode,
+      int maxSteps) {
+    BlockPos previous = start;
+    BlockPos current = next;
+    int weight = 1;
+    int steps = 0;
+    while (!positionToNode.containsKey(current)) {
+      List<BlockPos> neighbours = adjacency.get(current);
+      if (neighbours == null || neighbours.isEmpty()) {
+        return null;
+      }
+      BlockPos candidate = null;
+      for (BlockPos neighbour : neighbours) {
+        if (!neighbour.equals(previous)) {
+          candidate = neighbour;
+          break;
+        }
+      }
+      if (candidate == null) {
+        return null;
+      }
+      previous = current;
+      current = candidate;
+      weight++;
+      if (++steps > maxSteps) {
+        throw new IllegalStateException("Traversal exceeded dust graph bounds starting from " + start);
+      }
+    }
+    return new Traversal(current, weight);
+  }
+
+  private Map<DustPort, Integer> buildPortMapping(Map<BlockPos, Integer> positionToNode) {
+    Map<DustPort, Integer> mapping = new LinkedHashMap<>();
+    List<Map.Entry<BlockPos, List<DustPort>>> entries = new ArrayList<>(attachmentsByPosition.entrySet());
+    entries.sort((a, b) -> POSITION_ORDER.compare(a.getKey(), b.getKey()));
+    for (Map.Entry<BlockPos, List<DustPort>> entry : entries) {
+      BlockPos pos = entry.getKey();
+      Integer nodeId = positionToNode.get(pos);
+      if (nodeId == null) {
+        throw new IllegalStateException("No node for attachment at " + pos);
+      }
+      List<DustPort> ports = new ArrayList<>(entry.getValue());
+      ports.sort(DustPort::compare);
+      for (DustPort port : ports) {
+        mapping.put(port, nodeId);
+      }
+    }
+    return mapping;
+  }
+
+  private record Traversal(BlockPos target, int weight) {}
+
+  private record EdgeCandidate(int targetNode, int weight) {
+    private static final Comparator<EdgeCandidate> ORDER =
+        Comparator.comparingInt(EdgeCandidate::targetNode).thenComparingInt(EdgeCandidate::weight);
+  }
+}

--- a/engine/src/main/java/dev/fastquartz/engine/dust/DustCsrGraph.java
+++ b/engine/src/main/java/dev/fastquartz/engine/dust/DustCsrGraph.java
@@ -1,0 +1,124 @@
+package dev.fastquartz.engine.dust;
+
+import dev.fastquartz.engine.world.BlockPos;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+/** Immutable compressed sparse row representation of the dust network. */
+public final class DustCsrGraph {
+  private static final DustCsrGraph EMPTY =
+      new DustCsrGraph(
+          List.of(),
+          new int[0],
+          new int[] {0},
+          new int[0],
+          new int[0],
+          Collections.emptyMap(),
+          Collections.emptyMap());
+
+  private final List<BlockPos> nodePositions;
+  private final int[] islandIds;
+  private final int[] edgeIndex;
+  private final int[] edgeTargets;
+  private final int[] edgeWeights;
+  private final Map<DustPort, Integer> portToNode;
+  private final Map<BlockPos, Integer> positionToNode;
+
+  DustCsrGraph(
+      List<BlockPos> nodePositions,
+      int[] islandIds,
+      int[] edgeIndex,
+      int[] edgeTargets,
+      int[] edgeWeights,
+      Map<DustPort, Integer> portToNode,
+      Map<BlockPos, Integer> positionToNode) {
+    this.nodePositions = List.copyOf(nodePositions);
+    this.islandIds = islandIds.clone();
+    this.edgeIndex = edgeIndex.clone();
+    this.edgeTargets = edgeTargets.clone();
+    this.edgeWeights = edgeWeights.clone();
+    this.portToNode = Map.copyOf(portToNode);
+    this.positionToNode = Map.copyOf(positionToNode);
+
+    int nodeCount = this.nodePositions.size();
+    if (this.islandIds.length != nodeCount) {
+      throw new IllegalArgumentException("islandIds must align with node positions");
+    }
+    if (this.edgeIndex.length != nodeCount + 1) {
+      throw new IllegalArgumentException("edgeIndex must be nodeCount + 1");
+    }
+    if (this.edgeTargets.length != this.edgeWeights.length) {
+      throw new IllegalArgumentException("edgeTargets and edgeWeights length mismatch");
+    }
+  }
+
+  /** Returns an empty graph with no nodes or edges. */
+  public static DustCsrGraph empty() {
+    return EMPTY;
+  }
+
+  public int nodeCount() {
+    return nodePositions.size();
+  }
+
+  public int edgeCount() {
+    return edgeTargets.length;
+  }
+
+  public BlockPos nodePosition(int nodeId) {
+    return nodePositions.get(nodeId);
+  }
+
+  public int islandId(int nodeId) {
+    return islandIds[nodeId];
+  }
+
+  public int[] edgeIndex() {
+    return edgeIndex.clone();
+  }
+
+  public int[] edgeTargets() {
+    return edgeTargets.clone();
+  }
+
+  public int[] edgeWeights() {
+    return edgeWeights.clone();
+  }
+
+  public List<Edge> edgesFrom(int nodeId) {
+    int start = edgeIndex[nodeId];
+    int end = edgeIndex[nodeId + 1];
+    List<Edge> edges = new ArrayList<>(end - start);
+    for (int i = start; i < end; i++) {
+      edges.add(new Edge(edgeTargets[i], edgeWeights[i]));
+    }
+    return edges;
+  }
+
+  public OptionalInt nodeForPort(DustPort port) {
+    Objects.requireNonNull(port, "port");
+    Integer node = portToNode.get(port);
+    return node != null ? OptionalInt.of(node) : OptionalInt.empty();
+  }
+
+  public OptionalInt nodeForPosition(BlockPos pos) {
+    Objects.requireNonNull(pos, "pos");
+    Integer node = positionToNode.get(pos);
+    return node != null ? OptionalInt.of(node) : OptionalInt.empty();
+  }
+
+  public Map<DustPort, Integer> portToNode() {
+    return portToNode;
+  }
+
+  public Map<BlockPos, Integer> positionToNode() {
+    return positionToNode;
+  }
+
+  /** Lightweight view of an outgoing edge. */
+  public record Edge(int targetNode, int weight) {}
+}

--- a/engine/src/main/java/dev/fastquartz/engine/dust/DustPort.java
+++ b/engine/src/main/java/dev/fastquartz/engine/dust/DustPort.java
@@ -1,0 +1,31 @@
+package dev.fastquartz.engine.dust;
+
+import java.util.Objects;
+
+/** Identifier for a component port that attaches to the dust network. */
+public record DustPort(int componentId, int portIndex) {
+  public DustPort {
+    if (componentId < 0) {
+      throw new IllegalArgumentException("componentId must be non-negative");
+    }
+    if (portIndex < 0) {
+      throw new IllegalArgumentException("portIndex must be non-negative");
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "DustPort{" + "componentId=" + componentId + ", portIndex=" + portIndex + '}';
+  }
+
+  /** Comparator-friendly view that orders ports by component id then port index. */
+  static int compare(DustPort a, DustPort b) {
+    Objects.requireNonNull(a, "a");
+    Objects.requireNonNull(b, "b");
+    int cmp = Integer.compare(a.componentId(), b.componentId());
+    if (cmp != 0) {
+      return cmp;
+    }
+    return Integer.compare(a.portIndex(), b.portIndex());
+  }
+}

--- a/engine/src/test/java/dev/fastquartz/engine/dust/DustCsrBuilderTest.java
+++ b/engine/src/test/java/dev/fastquartz/engine/dust/DustCsrBuilderTest.java
@@ -1,0 +1,142 @@
+package dev.fastquartz.engine.dust;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.fastquartz.engine.world.BlockPos;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DustCsrBuilderTest {
+  @Test
+  void compressesLongBusIntoTwoNodes() {
+    int length = 64;
+    DustCsrBuilder builder = new DustCsrBuilder();
+    for (int x = 0; x < length; x++) {
+      builder.addDust(BlockPos.of(x, 0, 0));
+    }
+    DustPort source = new DustPort(1, 0);
+    DustPort sink = new DustPort(2, 0);
+    builder.attachPort(source, BlockPos.of(0, 0, 0));
+    builder.attachPort(sink, BlockPos.of(length - 1, 0, 0));
+
+    DustCsrGraph graph = builder.build();
+
+    assertEquals(2, graph.nodeCount());
+    assertEquals(BlockPos.of(0, 0, 0), graph.nodePosition(0));
+    assertEquals(BlockPos.of(length - 1, 0, 0), graph.nodePosition(1));
+    assertEquals(0, graph.nodeForPort(source).orElseThrow());
+    assertEquals(1, graph.nodeForPort(sink).orElseThrow());
+
+    int[] edgeIndex = graph.edgeIndex();
+    int[] edgeTargets = graph.edgeTargets();
+    int[] edgeWeights = graph.edgeWeights();
+
+    assertEquals(0, edgeIndex[0]);
+    assertEquals(1, edgeIndex[1]);
+    assertEquals(2, edgeIndex[2]);
+
+    assertEquals(1, edgeTargets[0]);
+    assertEquals(length - 1, edgeWeights[0]);
+    assertEquals(0, edgeTargets[1]);
+    assertEquals(length - 1, edgeWeights[1]);
+
+    double reduction = (double) length / graph.nodeCount();
+    assertTrue(reduction >= 5.0, "Compression ratio should be at least 5x");
+  }
+
+  @Test
+  void attachmentsSplitStraightRun() {
+    DustCsrBuilder builder = new DustCsrBuilder();
+    for (int x = 0; x <= 4; x++) {
+      builder.addDust(BlockPos.of(x, 0, 0));
+    }
+    DustPort start = new DustPort(10, 0);
+    DustPort mid = new DustPort(11, 0);
+    DustPort end = new DustPort(12, 0);
+    builder.attachPort(start, BlockPos.of(0, 0, 0));
+    builder.attachPort(mid, BlockPos.of(2, 0, 0));
+    builder.attachPort(end, BlockPos.of(4, 0, 0));
+
+    DustCsrGraph graph = builder.build();
+
+    int startNode = graph.nodeForPort(start).orElseThrow();
+    int midNode = graph.nodeForPort(mid).orElseThrow();
+    int endNode = graph.nodeForPort(end).orElseThrow();
+
+    assertEquals(3, graph.nodeCount());
+    assertEquals(BlockPos.of(0, 0, 0), graph.nodePosition(startNode));
+    assertEquals(BlockPos.of(2, 0, 0), graph.nodePosition(midNode));
+    assertEquals(BlockPos.of(4, 0, 0), graph.nodePosition(endNode));
+
+    List<DustCsrGraph.Edge> startEdges = graph.edgesFrom(startNode);
+    assertEquals(1, startEdges.size());
+    assertEquals(midNode, startEdges.get(0).targetNode());
+    assertEquals(2, startEdges.get(0).weight());
+
+    List<DustCsrGraph.Edge> midEdges = graph.edgesFrom(midNode);
+    assertEquals(2, midEdges.size());
+    assertTrue(midEdges.stream().anyMatch(e -> e.targetNode() == startNode && e.weight() == 2));
+    assertTrue(midEdges.stream().anyMatch(e -> e.targetNode() == endNode && e.weight() == 2));
+  }
+
+  @Test
+  void junctionProducesStarGraph() {
+    DustCsrBuilder builder = new DustCsrBuilder();
+    BlockPos center = BlockPos.of(0, 0, 0);
+    BlockPos north = BlockPos.of(0, 0, -1);
+    BlockPos south = BlockPos.of(0, 0, 1);
+    BlockPos east = BlockPos.of(1, 0, 0);
+    BlockPos west = BlockPos.of(-1, 0, 0);
+
+    builder
+        .addDust(center)
+        .addDust(north)
+        .addDust(south)
+        .addDust(east)
+        .addDust(west);
+
+    DustPort northPort = new DustPort(20, 0);
+    DustPort southPort = new DustPort(21, 0);
+    DustPort eastPort = new DustPort(22, 0);
+    DustPort westPort = new DustPort(23, 0);
+    builder.attachPort(northPort, north);
+    builder.attachPort(southPort, south);
+    builder.attachPort(eastPort, east);
+    builder.attachPort(westPort, west);
+
+    DustCsrGraph graph = builder.build();
+
+    assertEquals(5, graph.nodeCount());
+    int centerNode = graph.nodeForPosition(center).orElseThrow();
+    List<DustCsrGraph.Edge> centerEdges = graph.edgesFrom(centerNode);
+    assertEquals(4, centerEdges.size());
+    assertTrue(centerEdges.stream().allMatch(edge -> edge.weight() == 1));
+
+    int northNode = graph.nodeForPort(northPort).orElseThrow();
+    int southNode = graph.nodeForPort(southPort).orElseThrow();
+    int eastNode = graph.nodeForPort(eastPort).orElseThrow();
+    int westNode = graph.nodeForPort(westPort).orElseThrow();
+
+    assertTrue(
+        graph.edgesFrom(northNode).stream()
+            .anyMatch(edge -> edge.targetNode() == centerNode && edge.weight() == 1));
+    assertTrue(
+        graph.edgesFrom(southNode).stream()
+            .anyMatch(edge -> edge.targetNode() == centerNode && edge.weight() == 1));
+    assertTrue(
+        graph.edgesFrom(eastNode).stream()
+            .anyMatch(edge -> edge.targetNode() == centerNode && edge.weight() == 1));
+    assertTrue(
+        graph.edgesFrom(westNode).stream()
+            .anyMatch(edge -> edge.targetNode() == centerNode && edge.weight() == 1));
+  }
+
+  @Test
+  void attachingPortToMissingDustFails() {
+    DustCsrBuilder builder = new DustCsrBuilder();
+    builder.addDust(BlockPos.of(0, 0, 0));
+    builder.attachPort(new DustPort(30, 0), BlockPos.of(5, 0, 0));
+
+    assertThrows(IllegalStateException.class, builder::build);
+  }
+}


### PR DESCRIPTION
## Summary
- implement a DustCsrBuilder that discovers dust islands, compresses straight runs, and emits CSR arrays
- add DustCsrGraph/DustPort support for querying node metadata and port mappings
- cover compression, junction, attachment splitting, and validation scenarios with unit tests

## Testing
- ./gradlew :engine:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cc94bf88088323aba9f976630dc1a1