### PR TITLE
Implement CPU dust propagation with bucketed settle

### DIFF
--- a/engine/src/main/java/dev/fastquartz/engine/dust/CpuDustPropagator.java
+++ b/engine/src/main/java/dev/fastquartz/engine/dust/CpuDustPropagator.java
@@ -1,0 +1,296 @@
+package dev.fastquartz.engine.dust;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/** CPU implementation of the bucketed dust frontier settle. */
+public final class CpuDustPropagator implements DustPropagator {
+  private int nodeCount;
+
+  private int[] nodeIslandIds = new int[0];
+  private int[][] nodesByIsland = new int[0][];
+  private boolean[] islandDirty = new boolean[0];
+
+  private int[] edgeIndex = new int[0];
+  private int[] edgeTargets = new int[0];
+  private int[] edgeWeights = new int[0];
+
+  private int[] settledLevels = new int[0];
+  private int[] previousLevels = new int[0];
+  private int[] sourceLevels = new int[0];
+  private int[] pendingSourceLevels = new int[0];
+  private boolean[] touchedSourceFlags = new boolean[0];
+
+  private final IntQueue[] buckets = new IntQueue[MAX_POWER_LEVEL + 1];
+  private final IntArrayList changedNodes = new IntArrayList();
+  private final IntArrayList dirtyIslands = new IntArrayList();
+  private final IntArrayList touchedNodes = new IntArrayList();
+
+  public CpuDustPropagator() {
+    for (int level = 0; level < buckets.length; level++) {
+      buckets[level] = new IntQueue();
+    }
+  }
+
+  @Override
+  public void reset(DustCsrGraph graph) {
+    Objects.requireNonNull(graph, "graph");
+    nodeCount = graph.nodeCount();
+
+    settledLevels = new int[nodeCount];
+    previousLevels = new int[nodeCount];
+    sourceLevels = new int[nodeCount];
+    pendingSourceLevels = new int[nodeCount];
+    touchedSourceFlags = new boolean[nodeCount];
+
+    nodeIslandIds = new int[nodeCount];
+    for (int nodeId = 0; nodeId < nodeCount; nodeId++) {
+      nodeIslandIds[nodeId] = graph.islandId(nodeId);
+    }
+    nodesByIsland = buildNodesByIsland(nodeIslandIds);
+    islandDirty = new boolean[nodesByIsland.length];
+
+    edgeIndex = graph.edgeIndex();
+    edgeTargets = graph.edgeTargets();
+    edgeWeights = graph.edgeWeights();
+
+    changedNodes.clear();
+    dirtyIslands.clear();
+    touchedNodes.clear();
+  }
+
+  @Override
+  public int[] propagate(List<Source> changedSources) {
+    Objects.requireNonNull(changedSources, "changedSources");
+    if (changedSources.isEmpty()) {
+      return new int[0];
+    }
+
+    touchedNodes.clear();
+    for (int i = 0; i < changedSources.size(); i++) {
+      Source source = DustPropagator.requireNonNull(changedSources.get(i));
+      int nodeId = source.nodeId();
+      if (nodeId >= nodeCount) {
+        throw new IllegalArgumentException("nodeId " + nodeId + " out of bounds (nodeCount=" + nodeCount + ")");
+      }
+      if (!touchedSourceFlags[nodeId]) {
+        touchedSourceFlags[nodeId] = true;
+        touchedNodes.add(nodeId);
+      }
+      pendingSourceLevels[nodeId] = source.powerLevel();
+    }
+
+    boolean anyDirty = false;
+    for (int i = 0; i < touchedNodes.size(); i++) {
+      int nodeId = touchedNodes.get(i);
+      int newLevel = pendingSourceLevels[nodeId];
+      int oldLevel = sourceLevels[nodeId];
+      touchedSourceFlags[nodeId] = false;
+      if (newLevel == oldLevel) {
+        continue;
+      }
+      sourceLevels[nodeId] = newLevel;
+      markIslandDirty(nodeIslandIds[nodeId]);
+      anyDirty = true;
+    }
+    touchedNodes.clear();
+
+    if (!anyDirty) {
+      return new int[0];
+    }
+
+    changedNodes.clear();
+    for (int i = 0; i < dirtyIslands.size(); i++) {
+      int islandId = dirtyIslands.get(i);
+      settleIsland(islandId);
+      islandDirty[islandId] = false;
+    }
+    dirtyIslands.clear();
+
+    return changedNodes.toArray();
+  }
+
+  @Override
+  public int powerLevel(int nodeId) {
+    if (nodeId < 0 || nodeId >= nodeCount) {
+      throw new IllegalArgumentException("nodeId " + nodeId + " out of bounds");
+    }
+    return settledLevels[nodeId];
+  }
+
+  private void markIslandDirty(int islandId) {
+    if (islandId < 0 || islandId >= islandDirty.length) {
+      return;
+    }
+    if (!islandDirty[islandId]) {
+      islandDirty[islandId] = true;
+      dirtyIslands.add(islandId);
+    }
+  }
+
+  private void settleIsland(int islandId) {
+    int[] nodes = islandId < nodesByIsland.length ? nodesByIsland[islandId] : null;
+    if (nodes == null || nodes.length == 0) {
+      return;
+    }
+
+    for (IntQueue bucket : buckets) {
+      bucket.clear();
+    }
+
+    for (int nodeId : nodes) {
+      previousLevels[nodeId] = settledLevels[nodeId];
+      settledLevels[nodeId] = 0;
+    }
+
+    for (int nodeId : nodes) {
+      int level = sourceLevels[nodeId];
+      if (level > 0) {
+        buckets[level].add(nodeId);
+      }
+    }
+
+    for (int level = MAX_POWER_LEVEL; level >= 0; level--) {
+      IntQueue queue = buckets[level];
+      while (!queue.isEmpty()) {
+        int nodeId = queue.poll();
+        if (level <= settledLevels[nodeId]) {
+          continue;
+        }
+        settledLevels[nodeId] = level;
+        int edgeStart = edgeIndex[nodeId];
+        int edgeEnd = edgeIndex[nodeId + 1];
+        for (int edge = edgeStart; edge < edgeEnd; edge++) {
+          int dst = edgeTargets[edge];
+          if (nodeIslandIds[dst] != islandId) {
+            continue;
+          }
+          int newLevel = level - edgeWeights[edge];
+          if (newLevel <= 0) {
+            continue;
+          }
+          if (newLevel > settledLevels[dst]) {
+            buckets[newLevel].add(dst);
+          }
+        }
+      }
+    }
+
+    for (int nodeId : nodes) {
+      if (settledLevels[nodeId] != previousLevels[nodeId]) {
+        changedNodes.add(nodeId);
+      }
+    }
+  }
+
+  private static int[][] buildNodesByIsland(int[] nodeIslandIds) {
+    if (nodeIslandIds.length == 0) {
+      return new int[0][];
+    }
+    int maxIsland = 0;
+    for (int islandId : nodeIslandIds) {
+      if (islandId > maxIsland) {
+        maxIsland = islandId;
+      }
+    }
+    IntArrayList[] nodes = new IntArrayList[maxIsland + 1];
+    for (int nodeId = 0; nodeId < nodeIslandIds.length; nodeId++) {
+      int islandId = nodeIslandIds[nodeId];
+      IntArrayList list = nodes[islandId];
+      if (list == null) {
+        list = new IntArrayList();
+        nodes[islandId] = list;
+      }
+      list.add(nodeId);
+    }
+    int[][] result = new int[maxIsland + 1][];
+    for (int islandId = 0; islandId <= maxIsland; islandId++) {
+      IntArrayList list = nodes[islandId];
+      result[islandId] = list != null ? list.toArray() : new int[0];
+    }
+    return result;
+  }
+
+  private static final class IntQueue {
+    private static final int INITIAL_CAPACITY = 8;
+
+    private int[] elements = new int[INITIAL_CAPACITY];
+    private int head;
+    private int tail;
+
+    void add(int value) {
+      ensureCapacity();
+      elements[tail++] = value;
+    }
+
+    int poll() {
+      if (isEmpty()) {
+        throw new IllegalStateException("Queue is empty");
+      }
+      int value = elements[head++];
+      if (head == tail) {
+        head = 0;
+        tail = 0;
+      }
+      return value;
+    }
+
+    boolean isEmpty() {
+      return head == tail;
+    }
+
+    void clear() {
+      head = 0;
+      tail = 0;
+    }
+
+    private void ensureCapacity() {
+      if (tail < elements.length) {
+        return;
+      }
+      if (head > 0) {
+        int size = tail - head;
+        System.arraycopy(elements, head, elements, 0, size);
+        head = 0;
+        tail = size;
+        return;
+      }
+      int newCapacity = elements.length * 2;
+      elements = Arrays.copyOf(elements, newCapacity);
+    }
+  }
+
+  private static final class IntArrayList {
+    private static final int INITIAL_CAPACITY = 8;
+
+    private int[] elements = new int[INITIAL_CAPACITY];
+    private int size;
+
+    void add(int value) {
+      if (size == elements.length) {
+        elements = Arrays.copyOf(elements, size * 2);
+      }
+      elements[size++] = value;
+    }
+
+    int get(int index) {
+      if (index < 0 || index >= size) {
+        throw new IndexOutOfBoundsException("index " + index + " out of bounds for size " + size);
+      }
+      return elements[index];
+    }
+
+    int size() {
+      return size;
+    }
+
+    void clear() {
+      size = 0;
+    }
+
+    int[] toArray() {
+      return Arrays.copyOf(elements, size);
+    }
+  }
+}

--- a/engine/src/main/java/dev/fastquartz/engine/dust/DustPropagator.java
+++ b/engine/src/main/java/dev/fastquartz/engine/dust/DustPropagator.java
@@ -1,0 +1,56 @@
+package dev.fastquartz.engine.dust;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Interface for dust power propagation backends. Implementations settle the compressed dust network
+ * to a deterministic fixed point when component sources change.
+ */
+public interface DustPropagator {
+
+  /** Maximum power level a dust node can hold. */
+  int MAX_POWER_LEVEL = 15;
+
+  /**
+   * Resets the propagator to operate on the supplied compressed graph. All power state is cleared
+   * to zero.
+   */
+  void reset(DustCsrGraph graph);
+
+  /**
+   * Applies the supplied source updates and settles the dust network to a fixed point.
+   *
+   * <p>Each source identifies a dust node by id together with the power level emitted by
+   * components attached to that node. Implementations may aggregate additional component inputs or
+   * cached state; callers need only provide the nodes whose component-facing power changed.
+   *
+   * @param changedSources collection of source updates (node id, level)
+   * @return array of node identifiers whose resolved power level changed as a result of the settle
+   */
+  int[] propagate(List<Source> changedSources);
+
+  /** Returns the settled power level for the specified node. */
+  int powerLevel(int nodeId);
+
+  /** Immutable update describing the component power injected into a dust node. */
+  record Source(int nodeId, int powerLevel) {
+    public Source {
+      if (nodeId < 0) {
+        throw new IllegalArgumentException("nodeId must be non-negative");
+      }
+      if (powerLevel < 0 || powerLevel > MAX_POWER_LEVEL) {
+        throw new IllegalArgumentException("powerLevel must be in [0, 15]");
+      }
+    }
+
+    public static Source of(int nodeId, int powerLevel) {
+      return new Source(nodeId, powerLevel);
+    }
+  }
+
+  /** Utility for validating a non-null source entry. */
+  static Source requireNonNull(Source source) {
+    return Objects.requireNonNull(source, "source");
+  }
+}

--- a/engine/src/test/java/dev/fastquartz/engine/dust/CpuDustPropagatorTest.java
+++ b/engine/src/test/java/dev/fastquartz/engine/dust/CpuDustPropagatorTest.java
@@ -1,0 +1,137 @@
+package dev.fastquartz.engine.dust;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.fastquartz.engine.world.BlockPos;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CpuDustPropagatorTest {
+  private CpuDustPropagator propagator;
+
+  @BeforeEach
+  void setUp() {
+    propagator = new CpuDustPropagator();
+  }
+
+  @Test
+  void singleSourceLinePropagatesAndIsIdempotent() {
+    DustCsrGraph graph = lineGraph();
+    propagator.reset(graph);
+
+    int[] changed = propagator.propagate(List.of(DustPropagator.Source.of(0, 15)));
+    assertArrayEquals(new int[] {0, 1, 2}, changed);
+    assertEquals(15, propagator.powerLevel(0));
+    assertEquals(14, propagator.powerLevel(1));
+    assertEquals(13, propagator.powerLevel(2));
+
+    int[] second = propagator.propagate(List.of(DustPropagator.Source.of(0, 15)));
+    assertEquals(0, second.length);
+  }
+
+  @Test
+  void loweringSourceClearsFrontier() {
+    DustCsrGraph graph = lineGraph();
+    propagator.reset(graph);
+
+    propagator.propagate(List.of(DustPropagator.Source.of(0, 15)));
+
+    int[] changed = propagator.propagate(List.of(DustPropagator.Source.of(0, 0)));
+    assertArrayEquals(new int[] {0, 1, 2}, changed);
+    assertEquals(0, propagator.powerLevel(0));
+    assertEquals(0, propagator.powerLevel(1));
+    assertEquals(0, propagator.powerLevel(2));
+  }
+
+  @Test
+  void multipleSourcesCombineViaMaxRelaxation() {
+    DustCsrGraph graph = lineGraph();
+    propagator.reset(graph);
+
+    propagator.propagate(List.of(DustPropagator.Source.of(0, 0))); // ensure zero baseline
+
+    int[] changed =
+        propagator.propagate(
+            List.of(DustPropagator.Source.of(0, 12), DustPropagator.Source.of(2, 15)));
+    assertArrayEquals(new int[] {0, 1, 2}, changed);
+    assertEquals(13, propagator.powerLevel(0));
+    assertEquals(14, propagator.powerLevel(1));
+    assertEquals(15, propagator.powerLevel(2));
+  }
+
+  @Test
+  void updatesAreIsolatedByIsland() {
+    DustCsrGraph graph = twoIslandGraph();
+    propagator.reset(graph);
+
+    int[] first = propagator.propagate(List.of(DustPropagator.Source.of(0, 11)));
+    assertArrayEquals(new int[] {0, 1}, first);
+    assertEquals(11, propagator.powerLevel(0));
+    assertEquals(10, propagator.powerLevel(1));
+    assertEquals(0, propagator.powerLevel(2));
+    assertEquals(0, propagator.powerLevel(3));
+
+    int[] second = propagator.propagate(List.of(DustPropagator.Source.of(3, 9)));
+    assertArrayEquals(new int[] {2, 3}, second);
+    assertEquals(11, propagator.powerLevel(0));
+    assertEquals(10, propagator.powerLevel(1));
+    assertEquals(8, propagator.powerLevel(2));
+    assertEquals(9, propagator.powerLevel(3));
+  }
+
+  @Test
+  void invalidUpdatesAreRejected() {
+    DustCsrGraph graph = lineGraph();
+    propagator.reset(graph);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> propagator.propagate(List.of(DustPropagator.Source.of(5, 12))));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> propagator.propagate(List.of(DustPropagator.Source.of(0, 16))));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> propagator.propagate(List.of(DustPropagator.Source.of(-1, 5))));
+  }
+
+  private static DustCsrGraph lineGraph() {
+    List<BlockPos> positions =
+        List.of(BlockPos.of(0, 0, 0), BlockPos.of(1, 0, 0), BlockPos.of(2, 0, 0));
+    int[] islandIds = {0, 0, 0};
+    int[] edgeIndex = {0, 1, 3, 4};
+    int[] edgeTargets = {1, 0, 2, 1};
+    int[] edgeWeights = {1, 1, 1, 1};
+    Map<DustPort, Integer> portToNode = Map.of();
+    Map<BlockPos, Integer> positionToNode =
+        Map.of(positions.get(0), 0, positions.get(1), 1, positions.get(2), 2);
+    return new DustCsrGraph(
+        positions, islandIds, edgeIndex, edgeTargets, edgeWeights, portToNode, positionToNode);
+  }
+
+  private static DustCsrGraph twoIslandGraph() {
+    List<BlockPos> positions =
+        List.of(
+            BlockPos.of(0, 0, 0),
+            BlockPos.of(1, 0, 0),
+            BlockPos.of(10, 0, 0),
+            BlockPos.of(11, 0, 0));
+    int[] islandIds = {0, 0, 1, 1};
+    int[] edgeIndex = {0, 1, 2, 3, 4};
+    int[] edgeTargets = {1, 0, 3, 2};
+    int[] edgeWeights = {1, 1, 1, 1};
+    Map<DustPort, Integer> portToNode = Map.of();
+    Map<BlockPos, Integer> positionToNode =
+        Map.of(
+            positions.get(0), 0,
+            positions.get(1), 1,
+            positions.get(2), 2,
+            positions.get(3), 3);
+    return new DustCsrGraph(
+        positions, islandIds, edgeIndex, edgeTargets, edgeWeights, portToNode, positionToNode);
+  }
+}


### PR DESCRIPTION
## Summary
- add a DustPropagator interface defining source updates and node power queries
- implement a CPU-backed propagator that settles dirty islands using 16 power buckets and per-island scheduling
- cover propagation behaviour with unit tests for increases, decreases, multiple sources, isolation and validation

## Testing
- ./gradlew :engine:test

------
https://chatgpt.com/codex/tasks/task_e_68cc97a462d483238d13b89f616ce24f