### PR TITLE
FS-B6: add component adapters for core redstone blocks

### DIFF
--- a/engine/src/main/java/dev/fastquartz/engine/component/ComponentAdapters.java
+++ b/engine/src/main/java/dev/fastquartz/engine/component/ComponentAdapters.java
@@ -1,0 +1,242 @@
+package dev.fastquartz.engine.component;
+
+import dev.fastquartz.engine.world.BlockPos;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+
+/** Factory for deterministic wrappers around vanilla component logic. */
+public final class ComponentAdapters {
+  private static final Comparator<BlockPos> BLOCK_POS_ORDER =
+      Comparator.comparingInt(BlockPos::y)
+          .thenComparingInt(BlockPos::z)
+          .thenComparingInt(BlockPos::x);
+
+  private static final PreRunHook NO_OP =
+      new PreRunHook() {
+        @Override
+        public void run(ComponentWorldAccess world, BlockPos pos, int stateBits) {
+          // no-op
+        }
+      };
+
+  private ComponentAdapters() {}
+
+  /** Adapter used for torches, repeaters and other simple stateful components. */
+  public static ComponentAdapter standard(ComponentLogic logic) {
+    Objects.requireNonNull(logic, "logic");
+    return new StandardComponentAdapter(logic, NO_OP);
+  }
+
+  /** Adapter specialised for comparators that require container snapshots. */
+  public static ComponentAdapter comparator(
+      ComponentLogic logic, ComparatorSnapshotLocator snapshotLocator) {
+    Objects.requireNonNull(logic, "logic");
+    Objects.requireNonNull(snapshotLocator, "snapshotLocator");
+    return new StandardComponentAdapter(logic, new ComparatorPreRun(snapshotLocator));
+  }
+
+  /** Adapter wrapping observer behaviour with Stable-logic pulse coalescing. */
+  public static ObserverAdapter observer(ObserverLogic logic) {
+    Objects.requireNonNull(logic, "logic");
+    return new DefaultObserverAdapter(logic);
+  }
+
+  /** Adapter wrapping piston transactions. */
+  public static PistonAdapter piston(PistonLogic logic) {
+    Objects.requireNonNull(logic, "logic");
+    return new DefaultPistonAdapter(logic);
+  }
+
+  @FunctionalInterface
+  public interface ComponentAdapter {
+    void apply(ComponentContext context, BlockPos componentPos, int stateBits);
+  }
+
+  @FunctionalInterface
+  public interface ObserverAdapter {
+    void apply(
+        ComponentContext context,
+        BlockPos observerPos,
+        BlockPos observedPos,
+        int oldStateBits,
+        int newStateBits);
+  }
+
+  @FunctionalInterface
+  public interface PistonAdapter {
+    void apply(ComponentContext context, BlockPos componentPos, int stateBits);
+  }
+
+  @FunctionalInterface
+  public interface ComponentLogic {
+    void run(ComponentWorldAccess world, BlockPos pos, int stateBits);
+  }
+
+  @FunctionalInterface
+  public interface ObserverLogic {
+    void run(
+        ComponentWorldAccess world,
+        BlockPos observerPos,
+        BlockPos observedPos,
+        int oldStateBits,
+        int newStateBits);
+  }
+
+  @FunctionalInterface
+  public interface PistonLogic {
+    PistonTransaction evaluate(ComponentWorldAccess world, BlockPos pos, int stateBits);
+  }
+
+  @FunctionalInterface
+  public interface ComparatorSnapshotLocator {
+    Iterable<BlockPos> snapshotPositions(BlockPos comparatorPos, int stateBits);
+  }
+
+  public static final class PistonTransaction {
+    private final List<PistonMove> moves;
+    private final List<BlockPos> neighborUpdates;
+
+    public PistonTransaction(List<PistonMove> moves, List<BlockPos> neighborUpdates) {
+      this.moves = List.copyOf(Objects.requireNonNull(moves, "moves"));
+      this.neighborUpdates = neighborUpdates == null ? List.of() : List.copyOf(neighborUpdates);
+    }
+
+    public List<PistonMove> moves() {
+      return moves;
+    }
+
+    public List<BlockPos> neighborUpdates() {
+      return neighborUpdates;
+    }
+  }
+
+  public record PistonMove(BlockPos from, BlockPos to, int stateBits) {
+    public PistonMove {
+      Objects.requireNonNull(from, "from");
+      Objects.requireNonNull(to, "to");
+    }
+  }
+
+  private record ComparatorPreRun(ComparatorSnapshotLocator locator) implements PreRunHook {
+    @Override
+    public void run(ComponentWorldAccess world, BlockPos pos, int stateBits) {
+      Iterable<BlockPos> positions = locator.snapshotPositions(pos, stateBits);
+      if (positions == null) {
+        return;
+      }
+      for (BlockPos snapshotPos : positions) {
+        if (snapshotPos != null) {
+          world.readContainerSignal(snapshotPos);
+        }
+      }
+    }
+  }
+
+  private interface PreRunHook {
+    void run(ComponentWorldAccess world, BlockPos pos, int stateBits);
+  }
+
+  private static final class StandardComponentAdapter implements ComponentAdapter {
+    private final ComponentLogic logic;
+    private final PreRunHook preRun;
+
+    StandardComponentAdapter(ComponentLogic logic, PreRunHook preRun) {
+      this.logic = Objects.requireNonNull(logic, "logic");
+      this.preRun = Objects.requireNonNull(preRun, "preRun");
+    }
+
+    @Override
+    public void apply(ComponentContext context, BlockPos componentPos, int stateBits) {
+      Objects.requireNonNull(context, "context");
+      Objects.requireNonNull(componentPos, "componentPos");
+      ComponentWorldAccess world = context.createWorldAccess(componentPos);
+      preRun.run(world, componentPos, stateBits);
+      logic.run(world, componentPos, stateBits);
+    }
+  }
+
+  private static final class DefaultObserverAdapter implements ObserverAdapter {
+    private final ObserverLogic logic;
+
+    DefaultObserverAdapter(ObserverLogic logic) {
+      this.logic = Objects.requireNonNull(logic, "logic");
+    }
+
+    @Override
+    public void apply(
+        ComponentContext context,
+        BlockPos observerPos,
+        BlockPos observedPos,
+        int oldStateBits,
+        int newStateBits) {
+      Objects.requireNonNull(context, "context");
+      Objects.requireNonNull(observerPos, "observerPos");
+      Objects.requireNonNull(observedPos, "observedPos");
+      if (oldStateBits == newStateBits) {
+        return;
+      }
+      if (!context.observerPulseTracker().shouldEmit(context.tick(), observerPos, observedPos)) {
+        return;
+      }
+      ComponentWorldAccess world = context.createWorldAccess(observerPos);
+      logic.run(world, observerPos, observedPos, oldStateBits, newStateBits);
+    }
+  }
+
+  private static final class DefaultPistonAdapter implements PistonAdapter {
+    private final PistonLogic logic;
+
+    DefaultPistonAdapter(PistonLogic logic) {
+      this.logic = Objects.requireNonNull(logic, "logic");
+    }
+
+    @Override
+    public void apply(ComponentContext context, BlockPos componentPos, int stateBits) {
+      Objects.requireNonNull(context, "context");
+      Objects.requireNonNull(componentPos, "componentPos");
+      ComponentWorldAccess world = context.createWorldAccess(componentPos);
+      PistonTransaction transaction = logic.evaluate(world, componentPos, stateBits);
+      Objects.requireNonNull(transaction, "transaction");
+
+      List<PistonMove> orderedMoves = new ArrayList<>(transaction.moves());
+      orderedMoves.sort((a, b) -> compareBlockPos(a.from(), b.from()));
+
+      Set<BlockPos> seenFrom = new HashSet<>();
+      Set<BlockPos> seenTo = new HashSet<>();
+      for (PistonMove move : orderedMoves) {
+        if (!seenFrom.add(move.from())) {
+          throw new IllegalArgumentException("Duplicate piston source: " + move.from());
+        }
+        if (!seenTo.add(move.to())) {
+          throw new IllegalArgumentException("Duplicate piston destination: " + move.to());
+        }
+      }
+
+      for (PistonMove move : orderedMoves) {
+        world.setBlockStateBits(move.from(), 0);
+      }
+      for (PistonMove move : orderedMoves) {
+        world.setBlockStateBits(move.to(), move.stateBits());
+      }
+
+      TreeSet<BlockPos> neighbours = new TreeSet<>(BLOCK_POS_ORDER);
+      for (PistonMove move : orderedMoves) {
+        neighbours.add(move.from());
+        neighbours.add(move.to());
+      }
+      neighbours.addAll(transaction.neighborUpdates());
+      for (BlockPos neighbour : neighbours) {
+        world.markNeighborChanged(neighbour, componentPos);
+      }
+    }
+  }
+
+  private static int compareBlockPos(BlockPos a, BlockPos b) {
+    return BLOCK_POS_ORDER.compare(a, b);
+  }
+}

--- a/engine/src/main/java/dev/fastquartz/engine/component/ComponentContext.java
+++ b/engine/src/main/java/dev/fastquartz/engine/component/ComponentContext.java
@@ -1,0 +1,51 @@
+package dev.fastquartz.engine.component;
+
+import dev.fastquartz.engine.world.BlockPos;
+import dev.fastquartz.engine.world.ShadowWorld;
+import java.util.Objects;
+
+/**
+ * Execution context shared by component adapters. It bundles the shadow world view and the
+ * deterministic registries used during a micro-phase.
+ */
+public final class ComponentContext {
+  private final ShadowWorld shadowWorld;
+  private final ContainerSnapshotRegistry containerSnapshots;
+  private final ObserverPulseTracker observerPulseTracker;
+  private final long tick;
+
+  public ComponentContext(
+      ShadowWorld shadowWorld,
+      ContainerSnapshotRegistry containerSnapshots,
+      ObserverPulseTracker observerPulseTracker,
+      long tick) {
+    this.shadowWorld = Objects.requireNonNull(shadowWorld, "shadowWorld");
+    this.containerSnapshots = Objects.requireNonNull(containerSnapshots, "containerSnapshots");
+    this.observerPulseTracker =
+        Objects.requireNonNull(observerPulseTracker, "observerPulseTracker");
+    this.tick = tick;
+  }
+
+  public ShadowWorld shadowWorld() {
+    return shadowWorld;
+  }
+
+  public ContainerSnapshotRegistry containerSnapshots() {
+    return containerSnapshots;
+  }
+
+  public ObserverPulseTracker observerPulseTracker() {
+    return observerPulseTracker;
+  }
+
+  public long tick() {
+    return tick;
+  }
+
+  /**
+   * Creates a world access view using {@code sourcePos} as the implicit neighbour update source.
+   */
+  public ComponentWorldAccess createWorldAccess(BlockPos sourcePos) {
+    return new ComponentWorldAccess(shadowWorld, containerSnapshots, sourcePos);
+  }
+}

--- a/engine/src/main/java/dev/fastquartz/engine/component/ComponentWorldAccess.java
+++ b/engine/src/main/java/dev/fastquartz/engine/component/ComponentWorldAccess.java
@@ -1,0 +1,58 @@
+package dev.fastquartz.engine.component;
+
+import dev.fastquartz.engine.world.BlockPos;
+import dev.fastquartz.engine.world.ShadowWorld;
+import java.util.Objects;
+
+/**
+ * Minimal world facade exposed to vanilla component logic. All writes are staged in the associated
+ * {@link ShadowWorld} overlay to preserve deterministic ordering.
+ */
+public final class ComponentWorldAccess {
+  private final ShadowWorld shadowWorld;
+  private final ContainerSnapshotRegistry containerSnapshots;
+  private final BlockPos defaultSource;
+
+  public ComponentWorldAccess(
+      ShadowWorld shadowWorld,
+      ContainerSnapshotRegistry containerSnapshots,
+      BlockPos defaultSource) {
+    this.shadowWorld = Objects.requireNonNull(shadowWorld, "shadowWorld");
+    this.containerSnapshots = Objects.requireNonNull(containerSnapshots, "containerSnapshots");
+    this.defaultSource = Objects.requireNonNull(defaultSource, "defaultSource");
+  }
+
+  public int getBlockStateBits(BlockPos pos) {
+    Objects.requireNonNull(pos, "pos");
+    return shadowWorld.getBlockStateBits(pos);
+  }
+
+  public void setBlockStateBits(BlockPos pos, int stateBits) {
+    Objects.requireNonNull(pos, "pos");
+    shadowWorld.setBlockStateBits(pos, stateBits);
+  }
+
+  public void scheduleTick(BlockPos pos, int delayTicks, int priority) {
+    Objects.requireNonNull(pos, "pos");
+    shadowWorld.scheduleTick(pos, delayTicks, priority);
+  }
+
+  public void markNeighborChanged(BlockPos pos) {
+    markNeighborChanged(pos, defaultSource);
+  }
+
+  public void markNeighborChanged(BlockPos pos, BlockPos source) {
+    Objects.requireNonNull(pos, "pos");
+    Objects.requireNonNull(source, "source");
+    shadowWorld.markNeighborChanged(pos, source);
+  }
+
+  public int readContainerSignal(BlockPos pos) {
+    Objects.requireNonNull(pos, "pos");
+    return containerSnapshots.snapshot(pos, () -> shadowWorld.readContainerSignal(pos));
+  }
+
+  public ShadowWorld shadowWorld() {
+    return shadowWorld;
+  }
+}

--- a/engine/src/main/java/dev/fastquartz/engine/component/ContainerSnapshotRegistry.java
+++ b/engine/src/main/java/dev/fastquartz/engine/component/ContainerSnapshotRegistry.java
@@ -1,0 +1,37 @@
+package dev.fastquartz.engine.component;
+
+import dev.fastquartz.engine.world.BlockPos;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.IntSupplier;
+
+/**
+ * Caches comparator/container signals for the duration of a micro-phase.
+ *
+ * <p>The registry exposes deterministic snapshots: the first time a given position is observed the
+ * supplied reader is invoked and the value is memoised. Subsequent reads return the same cached
+ * value even if the underlying container changes. The caller is responsible for resetting or
+ * discarding the registry between ticks.
+ */
+public final class ContainerSnapshotRegistry {
+  private final Map<BlockPos, Integer> snapshots = new HashMap<>();
+
+  /** Retrieves the cached signal for {@code pos}, loading it via {@code reader} if absent. */
+  public int snapshot(BlockPos pos, IntSupplier reader) {
+    Objects.requireNonNull(pos, "pos");
+    Objects.requireNonNull(reader, "reader");
+    Integer cached = snapshots.get(pos);
+    if (cached != null) {
+      return cached;
+    }
+    int value = reader.getAsInt();
+    snapshots.put(pos, value);
+    return value;
+  }
+
+  /** Clears all cached entries. */
+  public void clear() {
+    snapshots.clear();
+  }
+}

--- a/engine/src/main/java/dev/fastquartz/engine/component/ObserverPulseTracker.java
+++ b/engine/src/main/java/dev/fastquartz/engine/component/ObserverPulseTracker.java
@@ -1,0 +1,31 @@
+package dev.fastquartz.engine.component;
+
+import dev.fastquartz.engine.world.BlockPos;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/** Tracks observer emissions to ensure Stable-logic coalescing behaviour. */
+public final class ObserverPulseTracker {
+  private long tick = Long.MIN_VALUE;
+  private final Set<ObserverKey> emitted = new HashSet<>();
+
+  /**
+   * Returns {@code true} if an observer at {@code observerPos} may emit for {@code sourcePos}
+   * during {@code currentTick}. Only the first call per tick for a given observer/source pair will
+   * succeed.
+   */
+  public boolean shouldEmit(long currentTick, BlockPos observerPos, BlockPos sourcePos) {
+    Objects.requireNonNull(observerPos, "observerPos");
+    Objects.requireNonNull(sourcePos, "sourcePos");
+    if (currentTick != tick) {
+      tick = currentTick;
+      emitted.clear();
+    }
+    return emitted.add(new ObserverKey(observerPos, sourcePos));
+  }
+
+  private record ObserverKey(BlockPos observer, BlockPos source) {
+    // value object for coalescing keys
+  }
+}

--- a/engine/src/main/java/dev/fastquartz/engine/dust/CpuDustPropagator.java
+++ b/engine/src/main/java/dev/fastquartz/engine/dust/CpuDustPropagator.java
@@ -72,7 +72,8 @@ public final class CpuDustPropagator implements DustPropagator {
       Source source = DustPropagator.requireNonNull(changedSources.get(i));
       int nodeId = source.nodeId();
       if (nodeId >= nodeCount) {
-        throw new IllegalArgumentException("nodeId " + nodeId + " out of bounds (nodeCount=" + nodeCount + ")");
+        throw new IllegalArgumentException(
+            "nodeId " + nodeId + " out of bounds (nodeCount=" + nodeCount + ")");
       }
       if (!touchedSourceFlags[nodeId]) {
         touchedSourceFlags[nodeId] = true;

--- a/engine/src/main/java/dev/fastquartz/engine/dust/DustCsrBuilder.java
+++ b/engine/src/main/java/dev/fastquartz/engine/dust/DustCsrBuilder.java
@@ -139,7 +139,8 @@ public final class DustCsrBuilder {
 
     Map<DustPort, Integer> portToNode = buildPortMapping(positionToNode);
 
-    return new DustCsrGraph(nodePositions, islandIds, edgeIndex, edgeTargets, edgeWeights, portToNode, positionToNode);
+    return new DustCsrGraph(
+        nodePositions, islandIds, edgeIndex, edgeTargets, edgeWeights, portToNode, positionToNode);
   }
 
   private void validateAttachmentPositions() {
@@ -263,7 +264,8 @@ public final class DustCsrBuilder {
       current = candidate;
       weight++;
       if (++steps > maxSteps) {
-        throw new IllegalStateException("Traversal exceeded dust graph bounds starting from " + start);
+        throw new IllegalStateException(
+            "Traversal exceeded dust graph bounds starting from " + start);
       }
     }
     return new Traversal(current, weight);
@@ -271,7 +273,8 @@ public final class DustCsrBuilder {
 
   private Map<DustPort, Integer> buildPortMapping(Map<BlockPos, Integer> positionToNode) {
     Map<DustPort, Integer> mapping = new LinkedHashMap<>();
-    List<Map.Entry<BlockPos, List<DustPort>>> entries = new ArrayList<>(attachmentsByPosition.entrySet());
+    List<Map.Entry<BlockPos, List<DustPort>>> entries =
+        new ArrayList<>(attachmentsByPosition.entrySet());
     entries.sort((a, b) -> POSITION_ORDER.compare(a.getKey(), b.getKey()));
     for (Map.Entry<BlockPos, List<DustPort>> entry : entries) {
       BlockPos pos = entry.getKey();
@@ -288,7 +291,9 @@ public final class DustCsrBuilder {
     return mapping;
   }
 
-  private record Traversal(BlockPos target, int weight) {}
+  private record Traversal(BlockPos target, int weight) {
+    // Record used during BFS traversal.
+  }
 
   private record EdgeCandidate(int targetNode, int weight) {
     private static final Comparator<EdgeCandidate> ORDER =

--- a/engine/src/main/java/dev/fastquartz/engine/dust/DustCsrGraph.java
+++ b/engine/src/main/java/dev/fastquartz/engine/dust/DustCsrGraph.java
@@ -120,5 +120,7 @@ public final class DustCsrGraph {
   }
 
   /** Lightweight view of an outgoing edge. */
-  public record Edge(int targetNode, int weight) {}
+  public record Edge(int targetNode, int weight) {
+    // Immutable edge descriptor.
+  }
 }

--- a/engine/src/main/java/dev/fastquartz/engine/dust/DustPropagator.java
+++ b/engine/src/main/java/dev/fastquartz/engine/dust/DustPropagator.java
@@ -21,9 +21,9 @@ public interface DustPropagator {
   /**
    * Applies the supplied source updates and settles the dust network to a fixed point.
    *
-   * <p>Each source identifies a dust node by id together with the power level emitted by
-   * components attached to that node. Implementations may aggregate additional component inputs or
-   * cached state; callers need only provide the nodes whose component-facing power changed.
+   * <p>Each source identifies a dust node by id together with the power level emitted by components
+   * attached to that node. Implementations may aggregate additional component inputs or cached
+   * state; callers need only provide the nodes whose component-facing power changed.
    *
    * @param changedSources collection of source updates (node id, level)
    * @return array of node identifiers whose resolved power level changed as a result of the settle

--- a/engine/src/main/java/dev/fastquartz/engine/world/ShadowWorld.java
+++ b/engine/src/main/java/dev/fastquartz/engine/world/ShadowWorld.java
@@ -92,6 +92,12 @@ public final class ShadowWorld {
     scheduledTicks.add(new ScheduledTick(pos, delayTicks, priority));
   }
 
+  /** Returns the cached comparator/container signal for the supplied position. */
+  public int readContainerSignal(BlockPos pos) {
+    Objects.requireNonNull(pos, "pos");
+    return delegate.readContainerSignal(pos);
+  }
+
   /** Applies all buffered mutations to the delegate in deterministic order. */
   public void commit() {
     for (Map.Entry<SectionPos, SectionChanges> entry : sectionChanges.entrySet()) {
@@ -229,5 +235,7 @@ public final class ShadowWorld {
     void scheduleTick(BlockPos pos, int delayTicks, int priority);
 
     void markNeighborChanged(BlockPos pos, BlockPos source);
+
+    int readContainerSignal(BlockPos pos);
   }
 }

--- a/engine/src/test/java/dev/fastquartz/engine/component/ComponentAdaptersTest.java
+++ b/engine/src/test/java/dev/fastquartz/engine/component/ComponentAdaptersTest.java
@@ -1,0 +1,254 @@
+package dev.fastquartz.engine.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.fastquartz.engine.world.BlockPos;
+import dev.fastquartz.engine.world.ShadowWorld;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntSupplier;
+import org.junit.jupiter.api.Test;
+
+class ComponentAdaptersTest {
+  @Test
+  void torchAdapterStagesWritesAndNotifications() {
+    RecordingWorld world = new RecordingWorld();
+    ShadowWorld shadowWorld = new ShadowWorld(world);
+    ComponentContext context =
+        new ComponentContext(
+            shadowWorld, new ContainerSnapshotRegistry(), new ObserverPulseTracker(), 10L);
+    BlockPos torchPos = BlockPos.of(0, 64, 0);
+    BlockPos neighbour = BlockPos.of(1, 64, 0);
+
+    ComponentAdapters.ComponentAdapter adapter =
+        ComponentAdapters.standard(
+            (access, pos, stateBits) -> {
+              assertEquals(torchPos, pos);
+              assertEquals(12, stateBits);
+              assertEquals(0, access.getBlockStateBits(pos));
+              access.setBlockStateBits(pos, 99);
+              access.scheduleTick(pos, 3, 1);
+              access.markNeighborChanged(neighbour);
+            });
+
+    adapter.apply(context, torchPos, 12);
+
+    assertEquals(99, shadowWorld.getBlockStateBits(torchPos));
+    assertTrue(world.writes.isEmpty(), "writes should be delayed until commit");
+
+    shadowWorld.commit();
+
+    assertEquals(List.of(new BlockWrite(torchPos, 99)), world.writes);
+    assertEquals(List.of(new ScheduledTickCall(torchPos, 3, 1)), world.scheduledTicks);
+    assertEquals(
+        List.of(new NeighborCall(/* pos= */ neighbour, /* source= */ torchPos)),
+        world.neighbourNotifications);
+  }
+
+  @Test
+  void comparatorAdapterSnapshotsContainersOnce() {
+    RecordingWorld world = new RecordingWorld();
+    ShadowWorld shadowWorld = new ShadowWorld(world);
+    ComponentContext context =
+        new ComponentContext(
+            shadowWorld, new ContainerSnapshotRegistry(), new ObserverPulseTracker(), 20L);
+    BlockPos comparatorPos = BlockPos.of(5, 70, 5);
+    BlockPos containerPos = BlockPos.of(5, 70, 6);
+    AtomicInteger counter = new AtomicInteger();
+    world.setContainerSignal(containerPos, counter::incrementAndGet);
+
+    List<Integer> observed = new ArrayList<>();
+    ComponentAdapters.ComponentAdapter adapter =
+        ComponentAdapters.comparator(
+            (access, pos, stateBits) -> {
+              observed.add(access.readContainerSignal(containerPos));
+              access.setBlockStateBits(pos, 7);
+              observed.add(access.readContainerSignal(containerPos));
+            },
+            (pos, stateBits) -> List.of(containerPos));
+
+    adapter.apply(context, comparatorPos, 0);
+
+    assertEquals(List.of(1, 1), observed);
+    assertEquals(1, world.containerReads(containerPos));
+    assertEquals(7, shadowWorld.getBlockStateBits(comparatorPos));
+  }
+
+  @Test
+  void observerAdapterCoalescesPerTick() {
+    RecordingWorld world = new RecordingWorld();
+    ShadowWorld shadowWorld = new ShadowWorld(world);
+    ObserverPulseTracker tracker = new ObserverPulseTracker();
+    BlockPos observer = BlockPos.of(0, 70, 0);
+    BlockPos observedA = BlockPos.of(1, 70, 0);
+    BlockPos observedB = BlockPos.of(2, 70, 0);
+    AtomicInteger pulses = new AtomicInteger();
+    ComponentAdapters.ObserverAdapter adapter =
+        ComponentAdapters.observer(
+            (access, observerPos, observedPos, oldBits, newBits) -> {
+              pulses.incrementAndGet();
+              access.markNeighborChanged(observedPos);
+            });
+
+    ComponentContext tick10 =
+        new ComponentContext(shadowWorld, new ContainerSnapshotRegistry(), tracker, 10L);
+    adapter.apply(tick10, observer, observedA, 0, 1);
+    adapter.apply(tick10, observer, observedA, 1, 2); // coalesced
+    adapter.apply(tick10, observer, observedB, 3, 4); // different source → allowed
+    adapter.apply(tick10, observer, observedB, 4, 4); // no change
+    assertEquals(2, pulses.get());
+
+    ComponentContext tick11 =
+        new ComponentContext(shadowWorld, new ContainerSnapshotRegistry(), tracker, 11L);
+    adapter.apply(tick11, observer, observedA, 5, 6); // new tick resets coalescing
+    assertEquals(3, pulses.get());
+
+    shadowWorld.commit();
+    assertEquals(
+        List.of(
+            new NeighborCall(/* pos= */ observedA, /* source= */ observer),
+            new NeighborCall(/* pos= */ observedB, /* source= */ observer),
+            new NeighborCall(/* pos= */ observedA, /* source= */ observer)),
+        world.neighbourNotifications);
+  }
+
+  @Test
+  void pistonAdapterAppliesTransactionsDeterministically() {
+    RecordingWorld world = new RecordingWorld();
+    ShadowWorld shadowWorld = new ShadowWorld(world);
+    ComponentContext context =
+        new ComponentContext(
+            shadowWorld, new ContainerSnapshotRegistry(), new ObserverPulseTracker(), 30L);
+    BlockPos pistonPos = BlockPos.of(0, 64, 0);
+    BlockPos source = BlockPos.of(1, 64, 0);
+    BlockPos dest = BlockPos.of(2, 64, 0);
+    world.prime(source, 55);
+
+    ComponentAdapters.PistonAdapter adapter =
+        ComponentAdapters.piston(
+            (access, pos, stateBits) ->
+                new ComponentAdapters.PistonTransaction(
+                    List.of(new ComponentAdapters.PistonMove(source, dest, 77)),
+                    List.of(BlockPos.of(3, 64, 0))));
+
+    adapter.apply(context, pistonPos, 0);
+
+    assertEquals(0, shadowWorld.getBlockStateBits(source));
+    assertEquals(77, shadowWorld.getBlockStateBits(dest));
+
+    shadowWorld.commit();
+
+    assertEquals(List.of(new BlockWrite(source, 0), new BlockWrite(dest, 77)), world.writes);
+    assertEquals(
+        List.of(
+            new NeighborCall(/* pos= */ source, /* source= */ pistonPos),
+            new NeighborCall(/* pos= */ dest, /* source= */ pistonPos),
+            new NeighborCall(/* pos= */ BlockPos.of(3, 64, 0), /* source= */ pistonPos)),
+        world.neighbourNotifications);
+  }
+
+  @Test
+  void pistonAdapterRejectsDuplicateSourcesOrDestinations() {
+    RecordingWorld world = new RecordingWorld();
+    ShadowWorld shadowWorld = new ShadowWorld(world);
+    ComponentContext context =
+        new ComponentContext(
+            shadowWorld, new ContainerSnapshotRegistry(), new ObserverPulseTracker(), 40L);
+    BlockPos pistonPos = BlockPos.of(0, 64, 0);
+    BlockPos a = BlockPos.of(1, 64, 0);
+    BlockPos b = BlockPos.of(2, 64, 0);
+    BlockPos c = BlockPos.of(3, 64, 0);
+
+    ComponentAdapters.PistonAdapter duplicateSources =
+        ComponentAdapters.piston(
+            (access, pos, stateBits) ->
+                new ComponentAdapters.PistonTransaction(
+                    List.of(
+                        new ComponentAdapters.PistonMove(a, b, 1),
+                        new ComponentAdapters.PistonMove(a, c, 2)),
+                    List.of()));
+
+    assertThrows(
+        IllegalArgumentException.class, () -> duplicateSources.apply(context, pistonPos, 0));
+
+    ComponentAdapters.PistonAdapter duplicateDestinations =
+        ComponentAdapters.piston(
+            (access, pos, stateBits) ->
+                new ComponentAdapters.PistonTransaction(
+                    List.of(
+                        new ComponentAdapters.PistonMove(a, b, 1),
+                        new ComponentAdapters.PistonMove(c, b, 2)),
+                    List.of()));
+
+    assertThrows(
+        IllegalArgumentException.class, () -> duplicateDestinations.apply(context, pistonPos, 0));
+  }
+
+  private static final class RecordingWorld implements ShadowWorld.Delegate {
+    private final Map<BlockPos, Integer> states = new HashMap<>();
+    private final Map<BlockPos, IntSupplier> containerSignals = new HashMap<>();
+    private final Map<BlockPos, Integer> containerReads = new HashMap<>();
+    private final List<BlockWrite> writes = new ArrayList<>();
+    private final List<NeighborCall> neighbourNotifications = new ArrayList<>();
+    private final List<ScheduledTickCall> scheduledTicks = new ArrayList<>();
+
+    @Override
+    public int getBlockStateBits(BlockPos pos) {
+      return states.getOrDefault(pos, 0);
+    }
+
+    @Override
+    public void setBlockStateBits(BlockPos pos, int stateBits) {
+      states.put(pos, stateBits);
+      writes.add(new BlockWrite(pos, stateBits));
+    }
+
+    @Override
+    public void scheduleTick(BlockPos pos, int delayTicks, int priority) {
+      scheduledTicks.add(new ScheduledTickCall(pos, delayTicks, priority));
+    }
+
+    @Override
+    public void markNeighborChanged(BlockPos pos, BlockPos source) {
+      neighbourNotifications.add(new NeighborCall(pos, source));
+    }
+
+    @Override
+    public int readContainerSignal(BlockPos pos) {
+      IntSupplier supplier = containerSignals.get(pos);
+      int value = supplier == null ? 0 : supplier.getAsInt();
+      containerReads.merge(pos, 1, Integer::sum);
+      return value;
+    }
+
+    void prime(BlockPos pos, int stateBits) {
+      states.put(pos, stateBits);
+    }
+
+    void setContainerSignal(BlockPos pos, IntSupplier supplier) {
+      containerSignals.put(pos, Objects.requireNonNull(supplier, "supplier"));
+    }
+
+    int containerReads(BlockPos pos) {
+      return containerReads.getOrDefault(pos, 0);
+    }
+  }
+
+  private record BlockWrite(BlockPos pos, int stateBits) {
+    // Recording helper for block writes.
+  }
+
+  private record NeighborCall(BlockPos pos, BlockPos source) {
+    // Recording helper for neighbour notifications.
+  }
+
+  private record ScheduledTickCall(BlockPos pos, int delayTicks, int priority) {
+    // Recording helper for scheduled ticks.
+  }
+}

--- a/engine/src/test/java/dev/fastquartz/engine/dust/DustCsrBuilderTest.java
+++ b/engine/src/test/java/dev/fastquartz/engine/dust/DustCsrBuilderTest.java
@@ -88,12 +88,7 @@ class DustCsrBuilderTest {
     BlockPos east = BlockPos.of(1, 0, 0);
     BlockPos west = BlockPos.of(-1, 0, 0);
 
-    builder
-        .addDust(center)
-        .addDust(north)
-        .addDust(south)
-        .addDust(east)
-        .addDust(west);
+    builder.addDust(center).addDust(north).addDust(south).addDust(east).addDust(west);
 
     DustPort northPort = new DustPort(20, 0);
     DustPort southPort = new DustPort(21, 0);

--- a/engine/src/test/java/dev/fastquartz/engine/world/ShadowWorldTest.java
+++ b/engine/src/test/java/dev/fastquartz/engine/world/ShadowWorldTest.java
@@ -162,6 +162,11 @@ class ShadowWorldTest {
       neighbourNotifications.add(new NeighborCall(pos, source));
     }
 
+    @Override
+    public int readContainerSignal(BlockPos pos) {
+      return 0;
+    }
+
     void prime(BlockPos pos, int stateBits) {
       states.put(pos, stateBits);
     }


### PR DESCRIPTION
## Summary
- add component adapter framework with shared context, container snapshot caching, observer pulse tracking, and piston transactions
- expose a deterministic world access bridge for adapters and extend ShadowWorld with container signal reads
- cover adapters with unit tests alongside formatting fixes needed for existing dust records

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68cd619723e88323bc0a3d9ef294dd0b